### PR TITLE
[feature] 개인목표 작성 API

### DIFF
--- a/docker/init.sql
+++ b/docker/init.sql
@@ -119,6 +119,7 @@ CREATE TABLE mission_member
     service_status              VARCHAR(10)               NOT NULL,
     mission_id                  BIGINT                    NOT NULL,
     user_id                     BIGINT,
+    goal                        VARCHAR(16),
     CONSTRAINT fk_mission_member_user_id FOREIGN KEY (user_id) REFERENCES users (user_id),
     CONSTRAINT fk_mission_member_mission_id FOREIGN KEY (mission_id) REFERENCES mission (mission_id)
 );

--- a/src/main/kotlin/com/alloon/alloonserver/api/controller/mission/MissionController.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/api/controller/mission/MissionController.kt
@@ -1,16 +1,19 @@
 package com.alloon.alloonserver.api.controller.mission
 
 import com.alloon.alloonserver.api.controller.mission.request.CreateMissionRequest
+import com.alloon.alloonserver.api.controller.mission.request.UpdateMissionMemberGoalRequest
 import com.alloon.alloonserver.api.controller.mission.response.CreateMissionResponse
 import com.alloon.alloonserver.api.controller.mission.response.FindPopularMissionsResponse
 import com.alloon.alloonserver.api.controller.mission.response.FindMissionInfoResponse
 import com.alloon.alloonserver.common.constant.SuccessCode.*
 import com.alloon.alloonserver.common.response.DefaultListResponse
+import com.alloon.alloonserver.common.response.DefaultResponse
 import com.alloon.alloonserver.common.response.DefaultSingleResponse
 import com.alloon.alloonserver.common.util.UserUtility
 import com.alloon.alloonserver.config.SwaggerConfig.Companion.ACCESS_TOKEN_KEY
 import com.alloon.alloonserver.service.mission.MissionService
 import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
@@ -116,5 +119,29 @@ class MissionController(
         val missionInfo = missionService.findMissionInfo(missionId)
         val response = FindMissionInfoResponse.of(missionInfo)
         return DefaultSingleResponse.toResponseEntity(FOUND_MISSION_INFO, response)
+    }
+
+    @PatchMapping("/api/missions/{missionId}/mission-members/goal")
+    @Operation(summary = "챌린지 개인목표 작성", security = [SecurityRequirement(name = ACCESS_TOKEN_KEY)])
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "챌린지 개인목표 작성 성공"),
+            ApiResponse(responseCode = "401", description = "승인되지 않은 요청입니다. 다시 로그인 해주세요."),
+            ApiResponse(responseCode = "403", description = "권한이 없는 요청입니다. 로그인 후에 다시 시도 해주세요."),
+            ApiResponse(responseCode = "404", description = "존재하지 않는 미션 멤버입니다."),
+        ]
+    )
+    fun updateMissionMemberGoal(
+        principal: Principal,
+        @PathVariable @Parameter(description = "챌린지 id", example = "1") missionId: Long,
+        @RequestBody @Valid request: UpdateMissionMemberGoalRequest,
+    ): ResponseEntity<DefaultResponse> {
+        missionService.updateMissionMemberGoal(
+            UserUtility.getUserId(principal),
+            missionId,
+            request.toServiceDto()
+        )
+
+        return DefaultResponse.toResponseEntity(MISSION_MEMBER_GOAL_UPDATED)
     }
 }

--- a/src/main/kotlin/com/alloon/alloonserver/api/controller/mission/request/UpdateMissionMemberGoalRequest.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/api/controller/mission/request/UpdateMissionMemberGoalRequest.kt
@@ -1,0 +1,20 @@
+package com.alloon.alloonserver.api.controller.mission.request
+
+import com.alloon.alloonserver.service.mission.dto.UpdateMissionMemberGoalDto
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+
+@Schema(description = "챌린지 개인목표 작성 요청 객체")
+data class UpdateMissionMemberGoalRequest(
+
+    @Schema(description = "챌린지 개인목표", example = "열심히 운동하기!!")
+    @field:NotBlank(message = "개인목표는 필수 입력입니다.")
+    @field:Size(min = 1, max = 16, message = "개인목표는 1~16자만 가능합니다.")
+    val goal: String,
+) {
+
+    fun toServiceDto(): UpdateMissionMemberGoalDto {
+        return UpdateMissionMemberGoalDto(goal)
+    }
+}

--- a/src/main/kotlin/com/alloon/alloonserver/common/constant/SuccessCode.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/common/constant/SuccessCode.kt
@@ -26,6 +26,7 @@ enum class SuccessCode(
     FOUND_POPULAR_MISSIONS(OK, "지금 인기있는 챌린지를 전체 조회했습니다."),
     NO_POPULAR_MISSIONS(OK, "지금 인기있는 챌린지가 없습니다."),
     FOUND_MISSION_INFO(OK, "챌린지 소개를 조회했습니다."),
+    MISSION_MEMBER_GOAL_UPDATED(OK, "챌린지 개인목표 작성이 완료되었습니다."),
 
     // 201 Created
     MISSION_CREATED(CREATED, "미션 생성이 완료되었습니다."),

--- a/src/main/kotlin/com/alloon/alloonserver/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/config/SecurityConfig.kt
@@ -31,7 +31,8 @@ class SecurityConfig(
                     "/api/users/token",
                     "/api/users/password",
                     "/api/missions",
-                    "/api/missions/{missionId}/info"
+                    "/api/missions/{missionId}/info",
+                    "/api/missions/{missionId}/mission-members/goal"
                 ).authenticated()
                 it.anyRequest().permitAll()
             }

--- a/src/main/kotlin/com/alloon/alloonserver/domain/mission/MissionMember.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/domain/mission/MissionMember.kt
@@ -20,6 +20,9 @@ class MissionMember(
     @JoinColumn(name = "mission_id", nullable = false)
     val mission: Mission,
 
+    @Column(length = 16)
+    var goal: String? = null,
+
     @Column(nullable = false, length = 15)
     @Enumerated(value = EnumType.STRING)
     val status: MissionMemberStatus = MissionMemberStatus.PROGRESS,
@@ -27,4 +30,8 @@ class MissionMember(
     @Column(nullable = false)
     val isCreator: Boolean = true,
 ) : BasePermanentEntity() {
+
+    fun updateGoal(goal: String) {
+        this.goal = goal
+    }
 }

--- a/src/main/kotlin/com/alloon/alloonserver/domain/mission/custom/MissionMemberCustomRepository.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/domain/mission/custom/MissionMemberCustomRepository.kt
@@ -5,4 +5,6 @@ import com.alloon.alloonserver.domain.mission.MissionMember
 interface MissionMemberCustomRepository {
 
     fun find(id: Long): MissionMember?
+
+    fun findByUserIdAndMissionId(userId: Long, missionId: Long): MissionMember?
 }

--- a/src/main/kotlin/com/alloon/alloonserver/domain/mission/custom/MissionMemberCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/domain/mission/custom/MissionMemberCustomRepositoryImpl.kt
@@ -22,6 +22,19 @@ class MissionMemberCustomRepositoryImpl(
             ).fetchFirst()
     }
 
+    override fun findByUserIdAndMissionId(userId: Long, missionId: Long): MissionMember? {
+        return queryFactory
+            .selectFrom(missionMember)
+            .join(missionMember.user).fetchJoin()
+            .join(missionMember.mission).fetchJoin()
+            .where(
+                missionMember.user.id.eq(userId),
+                missionMember.mission.id.eq(missionId),
+                eqServiceStatus(ACTIVE)
+            )
+            .fetchFirst()
+    }
+
     private fun eqServiceStatus(serviceStatus: ServiceStatus?): BooleanExpression? =
         serviceStatus?.let { missionMember.serviceStatus.eq(serviceStatus) }
 }

--- a/src/main/kotlin/com/alloon/alloonserver/service/mission/MissionService.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/service/mission/MissionService.kt
@@ -1,6 +1,7 @@
 package com.alloon.alloonserver.service.mission
 
 import com.alloon.alloonserver.common.constant.ExceptionCode.MISSION_NOT_FOUND
+import com.alloon.alloonserver.common.constant.ExceptionCode.MISSION_MEMBER_NOT_FOUND
 import com.alloon.alloonserver.common.constant.ExceptionCode.USER_NOT_FOUND
 import com.alloon.alloonserver.common.response.CustomException
 import com.alloon.alloonserver.domain.mission.*
@@ -8,6 +9,7 @@ import com.alloon.alloonserver.service.mission.dto.FindPopularMissionsDto
 import com.alloon.alloonserver.domain.user.UserRepository
 import com.alloon.alloonserver.service.mission.dto.CreateMissionDto
 import com.alloon.alloonserver.service.mission.dto.FindMissionInfoDto
+import com.alloon.alloonserver.service.mission.dto.UpdateMissionMemberGoalDto
 import com.alloon.alloonserver.service.s3.S3Service
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -56,5 +58,13 @@ class MissionService(
     fun findMissionInfo(missionId: Long): FindMissionInfoDto {
         val mission = missionRepository.findInfoById(missionId) ?: throw CustomException(MISSION_NOT_FOUND)
         return FindMissionInfoDto.of(mission)
+    }
+
+    @Transactional
+    fun updateMissionMemberGoal(userId: Long, missionId: Long, dto: UpdateMissionMemberGoalDto) {
+        val missionMember = missionMemberRepository.findByUserIdAndMissionId(userId, missionId)
+            ?: throw CustomException(MISSION_MEMBER_NOT_FOUND)
+
+        missionMember.updateGoal(dto.goal)
     }
 }

--- a/src/main/kotlin/com/alloon/alloonserver/service/mission/dto/UpdateMissionMemberGoalDto.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/service/mission/dto/UpdateMissionMemberGoalDto.kt
@@ -1,0 +1,5 @@
+package com.alloon.alloonserver.service.mission.dto
+
+data class UpdateMissionMemberGoalDto(
+    val goal: String,
+)

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -119,6 +119,7 @@ CREATE TABLE mission_member
     service_status              VARCHAR(10)               NOT NULL,
     mission_id                  BIGINT                    NOT NULL,
     user_id                     BIGINT,
+    goal                        VARCHAR(16),
     CONSTRAINT fk_mission_member_user_id FOREIGN KEY (user_id) REFERENCES users (user_id),
     CONSTRAINT fk_mission_member_mission_id FOREIGN KEY (mission_id) REFERENCES mission (mission_id)
 );

--- a/src/test/kotlin/com/alloon/alloonserver/api/controller/mission/MissionControllerTest.kt
+++ b/src/test/kotlin/com/alloon/alloonserver/api/controller/mission/MissionControllerTest.kt
@@ -4,21 +4,23 @@ import com.alloon.alloonserver.api.controller.RestDocsSupport
 import com.alloon.alloonserver.api.controller.mission.request.CreateMissionHashtagRequest
 import com.alloon.alloonserver.api.controller.mission.request.CreateMissionRequest
 import com.alloon.alloonserver.api.controller.mission.request.CreateMissionRuleRequest
+import com.alloon.alloonserver.api.controller.mission.request.UpdateMissionMemberGoalRequest
 import com.alloon.alloonserver.domain.mission.Mission
 import com.alloon.alloonserver.service.mission.dto.FindPopularMissionsDto
 import com.alloon.alloonserver.service.mission.MissionService
 import com.alloon.alloonserver.service.mission.dto.CreateMissionRuleDto
 import com.alloon.alloonserver.service.mission.dto.FindMissionInfoDto
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
+import io.mockk.runs
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpHeaders.AUTHORIZATION
 import org.springframework.http.MediaType.APPLICATION_JSON
 import org.springframework.http.MediaType.MULTIPART_FORM_DATA_VALUE
 import org.springframework.mock.web.MockMultipartFile
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import java.time.LocalDate
@@ -152,6 +154,28 @@ class MissionControllerTest : RestDocsSupport() {
         // then
         resultActions.andExpect(status().isOk)
             .andExpect(jsonPath("$.message").value("챌린지 소개를 조회했습니다."))
+    }
+
+    @DisplayName("챌린지 멤버가 개인목표 작성을 성공하면 200을 반환한다")
+    @Test
+    fun givenValid_whenUpdateMissionMemberGoal_thenReturn200() {
+        // given
+        val request = UpdateMissionMemberGoalRequest("개인목표")
+
+        every { missionService.updateMissionMemberGoal(any(), any(), any()) } just runs
+
+        // when
+        val resultActions = mockMvc.perform(
+            patch("/api/missions/{missionId}/mission-members/goal", 1)
+                .header(AUTHORIZATION, "Bearer access-token")
+                .principal(mockPrincipal)
+                .contentType(APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+        )
+
+        // then
+        resultActions.andExpect(status().isOk)
+            .andExpect(jsonPath("$.message").value("챌린지 개인목표 작성이 완료되었습니다."))
     }
 
     private fun getCreateMissionRequest(): CreateMissionRequest {

--- a/src/test/kotlin/com/alloon/alloonserver/domain/mission/MissionMemberRepositoryTest.kt
+++ b/src/test/kotlin/com/alloon/alloonserver/domain/mission/MissionMemberRepositoryTest.kt
@@ -21,6 +21,7 @@ import java.time.LocalTime
 
 @ActiveProfiles("test")
 @SpringBootTest
+@Transactional
 @ContextConfiguration(initializers = [TestContainerInitializer::class])
 class MissionMemberRepositoryTest(
     @Autowired private val missionMemberRepository: MissionMemberRepository,
@@ -31,7 +32,6 @@ class MissionMemberRepositoryTest(
 
     @DisplayName("미션 멤버 식별자로 미션 멤버 조회가 정상 작동한다")
     @Test
-    @Transactional
     fun givenValid_whenFind_thenReturnTrue() {
         // given
         val missionMember = createAndSaveMissionMember()
@@ -45,16 +45,18 @@ class MissionMemberRepositoryTest(
 
     @DisplayName("사용자 id와 챌린지 id로 조회하면 일치하는 챌린지 멤버를 반환한다")
     @Test
-    @Transactional
     fun givenValid_whenFindByUserIdAndMissionId_thenReturnMissionMember() {
         // given
-        val userId = 1L
-        val missionId = 1L
-
         val missionMember = createAndSaveMissionMember()
+        val userId = missionMember.user?.id
+        val missionId = missionMember.mission.id
 
         // when
-        val result = missionMemberRepository.findByUserIdAndMissionId(userId, missionId)
+        val result = userId?.let { uid ->
+            missionId?.let { mid ->
+                missionMemberRepository.findByUserIdAndMissionId(uid, mid)
+            }
+        }
 
         // then
         assertThat(result).isEqualTo(missionMember)

--- a/src/test/kotlin/com/alloon/alloonserver/domain/mission/MissionMemberRepositoryTest.kt
+++ b/src/test/kotlin/com/alloon/alloonserver/domain/mission/MissionMemberRepositoryTest.kt
@@ -21,7 +21,6 @@ import java.time.LocalTime
 
 @ActiveProfiles("test")
 @SpringBootTest
-@Transactional
 @ContextConfiguration(initializers = [TestContainerInitializer::class])
 class MissionMemberRepositoryTest(
     @Autowired private val missionMemberRepository: MissionMemberRepository,
@@ -32,6 +31,7 @@ class MissionMemberRepositoryTest(
 
     @DisplayName("미션 멤버 식별자로 미션 멤버 조회가 정상 작동한다")
     @Test
+    @Transactional
     fun givenValid_whenFind_thenReturnTrue() {
         // given
         val missionMember = createAndSaveMissionMember()
@@ -45,6 +45,7 @@ class MissionMemberRepositoryTest(
 
     @DisplayName("사용자 id와 챌린지 id로 조회하면 일치하는 챌린지 멤버를 반환한다")
     @Test
+    @Transactional
     fun givenValid_whenFindByUserIdAndMissionId_thenReturnMissionMember() {
         // given
         val userId = 1L

--- a/src/test/kotlin/com/alloon/alloonserver/domain/mission/MissionMemberRepositoryTest.kt
+++ b/src/test/kotlin/com/alloon/alloonserver/domain/mission/MissionMemberRepositoryTest.kt
@@ -1,6 +1,5 @@
 package com.alloon.alloonserver.domain.mission
 
-import com.alloon.alloonserver.common.util.PasswordUtility
 import com.alloon.alloonserver.domain.user.Contact
 import com.alloon.alloonserver.domain.user.ContactRepository
 import com.alloon.alloonserver.domain.user.User
@@ -29,7 +28,6 @@ class MissionMemberRepositoryTest(
     @Autowired private val missionRepository: MissionRepository,
     @Autowired private val contactRepository: ContactRepository,
     @Autowired private val userRepository: UserRepository,
-    @Autowired private val passwordUtility: PasswordUtility,
 ) {
 
     @DisplayName("미션 멤버 식별자로 미션 멤버 조회가 정상 작동한다")
@@ -45,27 +43,41 @@ class MissionMemberRepositoryTest(
         assertThat(result).isEqualTo(result)
     }
 
+    @DisplayName("사용자 id와 챌린지 id로 조회하면 일치하는 챌린지 멤버를 반환한다")
+    @Test
+    fun givenValid_whenFindByUserIdAndMissionId_thenReturnMissionMember() {
+        // given
+        val userId = 1L
+        val missionId = 1L
+
+        val missionMember = createAndSaveMissionMember()
+
+        // when
+        val result = missionMemberRepository.findByUserIdAndMissionId(userId, missionId)
+
+        // then
+        assertThat(result).isEqualTo(missionMember)
+    }
+
     private fun createAndSaveMissionMember(): MissionMember {
         val mission = createAndSaveMission()
         val contact = contactRepository.save(
             Contact(
-                email = "tester@alloon.com",
+                email = "tester@photi.com",
                 verificationCode = "000000",
                 verifyYn = true
             )
         )
-
-        val encryptedPassword = passwordUtility.encryptPassword("password1!")
         val user = userRepository.save(
             User(
                 contact = contact,
                 username = "tester",
-                password = encryptedPassword,
+                password = "password1!",
                 imageUrl = ""
             )
         )
 
-        return missionMemberRepository.save(MissionMember(user = user, mission = mission, isCreator = true))
+        return missionMemberRepository.save(MissionMember(user = user, mission = mission))
     }
 
     private fun createAndSaveMission(): Mission {

--- a/src/test/kotlin/com/alloon/alloonserver/domain/mission/MissionMemberTest.kt
+++ b/src/test/kotlin/com/alloon/alloonserver/domain/mission/MissionMemberTest.kt
@@ -1,0 +1,53 @@
+package com.alloon.alloonserver.domain.mission
+
+import com.alloon.alloonserver.domain.user.Contact
+import com.alloon.alloonserver.domain.user.User
+import com.alloon.alloonserver.service.mission.dto.CreateMissionDto
+import com.alloon.alloonserver.service.mission.dto.CreateMissionHashtagDto
+import com.alloon.alloonserver.service.mission.dto.CreateMissionRuleDto
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+import java.time.LocalTime
+
+class MissionMemberTest {
+
+    @DisplayName("개인목표 작성이 정상 작동한다")
+    @Test
+    fun givenValid_whenUpdateGoal_thenReturn() {
+        // given
+        val contact = Contact(email = "tester@photi.com", verificationCode = "000000", verifyYn = true)
+        val user = User(contact = contact, username = "tester", password = "password1!", imageUrl = "")
+        val mission = Mission.toEntity(getCreateMissionDto())
+        val missionMember = MissionMember(user = user, mission = mission)
+
+        val goal = "개인목표"
+
+        // when
+        missionMember.updateGoal(goal)
+
+        // then
+        assertThat(missionMember.goal).isEqualTo(goal)
+    }
+
+    private fun getCreateMissionDto(): CreateMissionDto {
+        return CreateMissionDto(
+            "챌린지 이름",
+            true,
+            "챌린지 목표입니다.",
+            LocalTime.of(13, 0),
+            LocalDate.of(2024, 12, 1),
+            "https://url.kr/5MhHhD",
+            listOf(
+                CreateMissionRuleDto("챌린지 인증 룰1"),
+                CreateMissionRuleDto("챌린지 인증 룰2"),
+                CreateMissionRuleDto("챌린지 인증 룰3"),
+            ),
+            listOf(
+                CreateMissionHashtagDto("해시태그 1"),
+                CreateMissionHashtagDto("해시태그 2"),
+            )
+        )
+    }
+}

--- a/src/test/kotlin/com/alloon/alloonserver/service/mission/MissionServiceTest.kt
+++ b/src/test/kotlin/com/alloon/alloonserver/service/mission/MissionServiceTest.kt
@@ -1,6 +1,7 @@
 package com.alloon.alloonserver.service.mission
 
 import com.alloon.alloonserver.common.constant.ExceptionCode.MISSION_NOT_FOUND
+import com.alloon.alloonserver.common.constant.ExceptionCode.MISSION_MEMBER_NOT_FOUND
 import com.alloon.alloonserver.common.constant.ExceptionCode.USER_NOT_FOUND
 import com.alloon.alloonserver.common.response.CustomException
 import com.alloon.alloonserver.domain.mission.*
@@ -14,6 +15,7 @@ import com.alloon.alloonserver.service.mission.dto.CreateMissionDto
 import com.alloon.alloonserver.service.mission.dto.CreateMissionHashtagDto
 import com.alloon.alloonserver.service.mission.dto.CreateMissionRuleDto
 import com.alloon.alloonserver.service.mission.dto.FindMissionInfoDto
+import com.alloon.alloonserver.service.mission.dto.UpdateMissionMemberGoalDto
 import com.alloon.alloonserver.service.s3.S3Service
 import io.mockk.every
 import io.mockk.mockk
@@ -186,6 +188,44 @@ class MissionServiceTest : AbstractMailProperties {
             .isInstanceOf(CustomException::class.java)
             .extracting("exceptionCode")
             .isEqualTo(MISSION_NOT_FOUND)
+    }
+
+    @DisplayName("챌린지 멤버가 개인목표 작성을 하면 개인목표가 수정된다")
+    @Test
+    fun givenValid_whenUpdateMissionMemberGoal_thenReturn() {
+        // given
+        val userId = 1L
+        val missionId = 1L
+        val dto = UpdateMissionMemberGoalDto("개인목표")
+
+        mockkObject(Mission)
+        val mission = Mission.toEntity(getCreateMissionDto())
+        val missionMember = MissionMember(user = getUser(), mission = mission)
+
+        every { missionMemberRepository.findByUserIdAndMissionId(any(), any()) } returns missionMember
+
+        // when
+        missionService.updateMissionMemberGoal(userId, missionId, dto)
+
+        // then
+        assertThat(missionMember.goal).isEqualTo(dto.goal)
+    }
+
+    @DisplayName("등록되지 않은 챌린지 멤버가 개인목표 작성을 하면 예외가 발생한다")
+    @Test
+    fun givenNotFoundMissionMember_whenUpdateMissionMemberGoal_thenThrow() {
+        // given
+        val userId = 1L
+        val missionId = 1L
+        val dto = UpdateMissionMemberGoalDto("개인목표")
+
+        every { missionMemberRepository.findByUserIdAndMissionId(any(), any()) } returns null
+
+        // when & then
+        assertThatThrownBy { missionService.updateMissionMemberGoal(userId, missionId, dto) }
+            .isInstanceOf(CustomException::class.java)
+            .extracting("exceptionCode")
+            .isEqualTo(MISSION_MEMBER_NOT_FOUND)
     }
 
     private fun getUser(): User {

--- a/src/test/resources/init.sql
+++ b/src/test/resources/init.sql
@@ -100,6 +100,7 @@ CREATE TABLE mission_member
     service_status              VARCHAR(10)               NOT NULL,
     mission_id                  BIGINT                    NOT NULL,
     user_id                     BIGINT,
+    goal                        VARCHAR(16),
     CONSTRAINT fk_mission_member_user_id FOREIGN KEY (user_id) REFERENCES users (user_id),
     CONSTRAINT fk_mission_member_mission_id FOREIGN KEY (mission_id) REFERENCES mission (mission_id)
 );


### PR DESCRIPTION
## 📋 이슈 번호
- close #79 
  </br>

## 🛠 구현 사항
- 1~16자 입력 가능
- userId와 missionId로 조회할 때 일치하는 챌린지 멤버의 개인목표 업데이트
  </br>

## 📚 기타
- 
  </br>