### PR TITLE
[feature] 피드조회 - 파티원 API

### DIFF
--- a/src/main/kotlin/com/alloon/alloonserver/api/controller/mission/MissionController.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/api/controller/mission/MissionController.kt
@@ -5,10 +5,9 @@ import com.alloon.alloonserver.api.controller.mission.request.UpdateMissionMembe
 import com.alloon.alloonserver.api.controller.mission.response.CreateMissionResponse
 import com.alloon.alloonserver.api.controller.mission.response.FindPopularMissionsResponse
 import com.alloon.alloonserver.api.controller.mission.response.FindMissionInfoResponse
+import com.alloon.alloonserver.api.controller.mission.response.FindMissionMembersResponse
 import com.alloon.alloonserver.common.constant.SuccessCode.*
-import com.alloon.alloonserver.common.response.DefaultListResponse
-import com.alloon.alloonserver.common.response.DefaultResponse
-import com.alloon.alloonserver.common.response.DefaultSingleResponse
+import com.alloon.alloonserver.common.response.*
 import com.alloon.alloonserver.common.util.UserUtility
 import com.alloon.alloonserver.config.SwaggerConfig.Companion.ACCESS_TOKEN_KEY
 import com.alloon.alloonserver.service.mission.MissionService
@@ -143,5 +142,23 @@ class MissionController(
         )
 
         return DefaultResponse.toResponseEntity(MISSION_MEMBER_GOAL_UPDATED)
+    }
+
+    @GetMapping("/api/missions/{missionId}/mission-members")
+    @Operation(summary = "챌린지 파티원 조회", security = [SecurityRequirement(name = ACCESS_TOKEN_KEY)])
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "챌린지 파티원 조회 성공"),
+            ApiResponse(responseCode = "401", description = "승인되지 않은 요청입니다. 다시 로그인 해주세요."),
+            ApiResponse(responseCode = "403", description = "권한이 없는 요청입니다. 로그인 후에 다시 시도 해주세요."),
+        ]
+    )
+    fun findMissionMembers(
+        principal: Principal,
+        @PathVariable @Parameter(description = "챌린지 id", example = "1") missionId: Long,
+    ): ResponseEntity<DefaultPageResponse<FindMissionMembersResponse>> {
+        val missionMembers = missionService.findMissionMembers(UserUtility.getUserId(principal), missionId)
+        val response = FindMissionMembersResponse.of(missionMembers)
+        return DefaultPageResponse.toResponseEntity(FOUND_MISSION_MEMBERS, PageData(response, response.size.toLong()))
     }
 }

--- a/src/main/kotlin/com/alloon/alloonserver/api/controller/mission/MissionController.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/api/controller/mission/MissionController.kt
@@ -145,7 +145,11 @@ class MissionController(
     }
 
     @GetMapping("/api/missions/{missionId}/mission-members")
-    @Operation(summary = "챌린지 파티원 조회", security = [SecurityRequirement(name = ACCESS_TOKEN_KEY)])
+    @Operation(
+        summary = "챌린지 파티원 조회",
+        description = "파티장 -> 본인 -> 가입순으로 파티원이 전체 조회됩니다.",
+        security = [SecurityRequirement(name = ACCESS_TOKEN_KEY)]
+    )
     @ApiResponses(
         value = [
             ApiResponse(responseCode = "200", description = "챌린지 파티원 조회 성공"),

--- a/src/main/kotlin/com/alloon/alloonserver/api/controller/mission/response/FindMissionMembersResponse.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/api/controller/mission/response/FindMissionMembersResponse.kt
@@ -1,0 +1,46 @@
+package com.alloon.alloonserver.api.controller.mission.response
+
+import com.alloon.alloonserver.service.mission.dto.FindMissionMembersDto
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDateTime
+import java.time.temporal.ChronoUnit
+
+data class FindMissionMembersResponse(
+
+    @Schema(description = "파티원 식별자", example = "1")
+    val id: Long,
+
+    @Schema(description = "파티원 아이디", example = "photi")
+    val username: String,
+
+    @Schema(description = "파티원 프로필 이미지 url", example = "https://url.kr/5MhHhD")
+    val imageUrl: String,
+
+    @Schema(description = "파티장", example = "true")
+    val isCreator: Boolean,
+
+    @Schema(description = "파티원 활동 기간", example = "10")
+    val duration: Long,
+
+    @Schema(description = "파티원 개인목표", example = "열심히 운동하기!!")
+    val goal: String,
+) {
+
+    companion object {
+
+        fun of(missionMember: FindMissionMembersDto): FindMissionMembersResponse {
+            return FindMissionMembersResponse(
+                missionMember.id,
+                missionMember.username,
+                missionMember.imageUrl,
+                missionMember.isCreator,
+                ChronoUnit.DAYS.between(missionMember.joinedDate, LocalDateTime.now()) + 1,
+                missionMember.goal,
+            )
+        }
+
+        fun of(missionMembers: List<FindMissionMembersDto>): List<FindMissionMembersResponse> {
+            return missionMembers.map { of(it) }
+        }
+    }
+}

--- a/src/main/kotlin/com/alloon/alloonserver/api/controller/mission/response/FindMissionMembersResponse.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/api/controller/mission/response/FindMissionMembersResponse.kt
@@ -2,7 +2,7 @@ package com.alloon.alloonserver.api.controller.mission.response
 
 import com.alloon.alloonserver.service.mission.dto.FindMissionMembersDto
 import io.swagger.v3.oas.annotations.media.Schema
-import java.time.LocalDateTime
+import java.time.LocalDate
 import java.time.temporal.ChronoUnit
 
 data class FindMissionMembersResponse(
@@ -23,7 +23,7 @@ data class FindMissionMembersResponse(
     val duration: Long,
 
     @Schema(description = "파티원 개인목표", example = "열심히 운동하기!!")
-    val goal: String,
+    val goal: String?,
 ) {
 
     companion object {
@@ -34,7 +34,7 @@ data class FindMissionMembersResponse(
                 missionMember.username,
                 missionMember.imageUrl,
                 missionMember.isCreator,
-                ChronoUnit.DAYS.between(missionMember.joinedDate, LocalDateTime.now()) + 1,
+                ChronoUnit.DAYS.between(missionMember.joinedDate.toLocalDate(), LocalDate.now()) + 1,
                 missionMember.goal,
             )
         }

--- a/src/main/kotlin/com/alloon/alloonserver/common/constant/SuccessCode.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/common/constant/SuccessCode.kt
@@ -27,6 +27,7 @@ enum class SuccessCode(
     NO_POPULAR_MISSIONS(OK, "지금 인기있는 챌린지가 없습니다."),
     FOUND_MISSION_INFO(OK, "챌린지 소개를 조회했습니다."),
     MISSION_MEMBER_GOAL_UPDATED(OK, "챌린지 개인목표 작성이 완료되었습니다."),
+    FOUND_MISSION_MEMBERS(OK, "챌린지 파티원을 전체 조회했습니다."),
 
     // 201 Created
     MISSION_CREATED(CREATED, "미션 생성이 완료되었습니다."),

--- a/src/main/kotlin/com/alloon/alloonserver/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/config/SecurityConfig.kt
@@ -32,7 +32,8 @@ class SecurityConfig(
                     "/api/users/password",
                     "/api/missions",
                     "/api/missions/{missionId}/info",
-                    "/api/missions/{missionId}/mission-members/goal"
+                    "/api/missions/{missionId}/mission-members/goal",
+                    "/api/missions/{missionId}/mission-members",
                 ).authenticated()
                 it.anyRequest().permitAll()
             }

--- a/src/main/kotlin/com/alloon/alloonserver/domain/mission/custom/MissionMemberCustomRepository.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/domain/mission/custom/MissionMemberCustomRepository.kt
@@ -1,10 +1,13 @@
 package com.alloon.alloonserver.domain.mission.custom
 
 import com.alloon.alloonserver.domain.mission.MissionMember
+import com.alloon.alloonserver.service.mission.dto.FindMissionMembersDto
 
 interface MissionMemberCustomRepository {
 
     fun find(id: Long): MissionMember?
 
     fun findByUserIdAndMissionId(userId: Long, missionId: Long): MissionMember?
+
+    fun findAllByMissionId(userId: Long, missionId: Long): List<FindMissionMembersDto>
 }

--- a/src/main/kotlin/com/alloon/alloonserver/domain/mission/custom/MissionMemberCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/domain/mission/custom/MissionMemberCustomRepositoryImpl.kt
@@ -4,7 +4,10 @@ import com.alloon.alloonserver.domain.base.ServiceStatus
 import com.alloon.alloonserver.domain.base.ServiceStatus.ACTIVE
 import com.alloon.alloonserver.domain.mission.MissionMember
 import com.alloon.alloonserver.domain.mission.QMissionMember.missionMember
+import com.alloon.alloonserver.service.mission.dto.FindMissionMembersDto
+import com.alloon.alloonserver.service.mission.dto.QFindMissionMembersDto
 import com.querydsl.core.types.dsl.BooleanExpression
+import com.querydsl.core.types.dsl.CaseBuilder
 import com.querydsl.jpa.impl.JPAQueryFactory
 import org.springframework.stereotype.Repository
 
@@ -33,6 +36,32 @@ class MissionMemberCustomRepositoryImpl(
                 eqServiceStatus(ACTIVE)
             )
             .fetchFirst()
+    }
+
+    override fun findAllByMissionId(userId: Long, missionId: Long): List<FindMissionMembersDto> {
+        val spec = CaseBuilder()
+            .`when`(missionMember.isCreator.isTrue).then(1)
+            .`when`(missionMember.user.id.eq(userId)).then(2)
+            .otherwise(3)
+
+        return queryFactory
+            .select(
+                QFindMissionMembersDto(
+                    missionMember.id,
+                    missionMember.user.username,
+                    missionMember.user.imageUrl,
+                    missionMember.isCreator,
+                    missionMember.createDateTime,
+                    missionMember.goal
+                )
+            )
+            .from(missionMember)
+            .where(missionMember.mission.id.eq(missionId))
+            .orderBy(
+                spec.asc(),
+                missionMember.createDateTime.asc()
+            )
+            .fetch()
     }
 
     private fun eqServiceStatus(serviceStatus: ServiceStatus?): BooleanExpression? =

--- a/src/main/kotlin/com/alloon/alloonserver/service/mission/MissionService.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/service/mission/MissionService.kt
@@ -9,6 +9,7 @@ import com.alloon.alloonserver.service.mission.dto.FindPopularMissionsDto
 import com.alloon.alloonserver.domain.user.UserRepository
 import com.alloon.alloonserver.service.mission.dto.CreateMissionDto
 import com.alloon.alloonserver.service.mission.dto.FindMissionInfoDto
+import com.alloon.alloonserver.service.mission.dto.FindMissionMembersDto
 import com.alloon.alloonserver.service.mission.dto.UpdateMissionMemberGoalDto
 import com.alloon.alloonserver.service.s3.S3Service
 import org.springframework.stereotype.Service
@@ -66,5 +67,9 @@ class MissionService(
             ?: throw CustomException(MISSION_MEMBER_NOT_FOUND)
 
         missionMember.updateGoal(dto.goal)
+    }
+
+    fun findMissionMembers(userId: Long, missionId: Long): List<FindMissionMembersDto> {
+        return missionMemberRepository.findAllByMissionId(userId, missionId)
     }
 }

--- a/src/main/kotlin/com/alloon/alloonserver/service/mission/dto/FindMissionMembersDto.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/service/mission/dto/FindMissionMembersDto.kt
@@ -9,5 +9,5 @@ data class FindMissionMembersDto @QueryProjection constructor(
     val imageUrl: String,
     val isCreator: Boolean,
     val joinedDate: LocalDateTime,
-    val goal: String,
+    val goal: String?,
 )

--- a/src/main/kotlin/com/alloon/alloonserver/service/mission/dto/FindMissionMembersDto.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/service/mission/dto/FindMissionMembersDto.kt
@@ -1,0 +1,13 @@
+package com.alloon.alloonserver.service.mission.dto
+
+import com.querydsl.core.annotations.QueryProjection
+import java.time.LocalDateTime
+
+data class FindMissionMembersDto @QueryProjection constructor(
+    val id: Long,
+    val username: String,
+    val imageUrl: String,
+    val isCreator: Boolean,
+    val joinedDate: LocalDateTime,
+    val goal: String,
+)

--- a/src/test/kotlin/com/alloon/alloonserver/api/controller/mission/MissionControllerTest.kt
+++ b/src/test/kotlin/com/alloon/alloonserver/api/controller/mission/MissionControllerTest.kt
@@ -10,6 +10,7 @@ import com.alloon.alloonserver.service.mission.dto.FindPopularMissionsDto
 import com.alloon.alloonserver.service.mission.MissionService
 import com.alloon.alloonserver.service.mission.dto.CreateMissionRuleDto
 import com.alloon.alloonserver.service.mission.dto.FindMissionInfoDto
+import com.alloon.alloonserver.service.mission.dto.FindMissionMembersDto
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
@@ -24,6 +25,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import java.time.LocalDate
+import java.time.LocalDateTime
 import java.time.LocalTime
 
 class MissionControllerTest : RestDocsSupport() {
@@ -176,6 +178,26 @@ class MissionControllerTest : RestDocsSupport() {
         // then
         resultActions.andExpect(status().isOk)
             .andExpect(jsonPath("$.message").value("챌린지 개인목표 작성이 완료되었습니다."))
+    }
+
+    @DisplayName("챌린지 멤버가 챌린지 파티원 조회를 성공하면 200을 반환한다")
+    @Test
+    fun givenValid_whenFindMissionMembers_thenReturn200() {
+        // given
+        val dto = FindMissionMembersDto(1L, "tester", "", true, LocalDateTime.now(), "개인목표")
+
+        every { missionService.findMissionMembers(any(), any()) } returns listOf(dto)
+
+        // when
+        val resultActions = mockMvc.perform(
+            get("/api/missions/{missionId}/mission-members", 1)
+                .header(AUTHORIZATION, "Bearer access-token")
+                .principal(mockPrincipal)
+        )
+
+        // then
+        resultActions.andExpect(status().isOk)
+            .andExpect(jsonPath("$.message").value("챌린지 파티원을 전체 조회했습니다."))
     }
 
     private fun getCreateMissionRequest(): CreateMissionRequest {

--- a/src/test/kotlin/com/alloon/alloonserver/domain/mission/MissionMemberRepositoryTest.kt
+++ b/src/test/kotlin/com/alloon/alloonserver/domain/mission/MissionMemberRepositoryTest.kt
@@ -21,6 +21,7 @@ import java.time.LocalTime
 
 @ActiveProfiles("test")
 @SpringBootTest
+@Transactional
 @ContextConfiguration(initializers = [TestContainerInitializer::class])
 class MissionMemberRepositoryTest(
     @Autowired private val missionMemberRepository: MissionMemberRepository,
@@ -31,7 +32,6 @@ class MissionMemberRepositoryTest(
 
     @DisplayName("미션 멤버 식별자로 미션 멤버 조회가 정상 작동한다")
     @Test
-    @Transactional
     fun givenValid_whenFind_thenReturnTrue() {
         // given
         val missionMember = createAndSaveMissionMember()
@@ -45,7 +45,6 @@ class MissionMemberRepositoryTest(
 
     @DisplayName("사용자 id와 챌린지 id로 조회하면 일치하는 챌린지 멤버를 반환한다")
     @Test
-    @Transactional
     fun givenValid_whenFindByUserIdAndMissionId_thenReturnMissionMember() {
         // given
         val missionMember = createAndSaveMissionMember()

--- a/src/test/kotlin/com/alloon/alloonserver/domain/mission/MissionMemberRepositoryTest.kt
+++ b/src/test/kotlin/com/alloon/alloonserver/domain/mission/MissionMemberRepositoryTest.kt
@@ -62,24 +62,44 @@ class MissionMemberRepositoryTest(
         assertThat(result).isEqualTo(missionMember)
     }
 
+    @DisplayName("챌린지 id로 조회하면 정렬된 챌린지 멤버 리스트를 반환한다")
+    @Test
+    fun givenValid_whenFindAllByMissionId_thenReturnMissionMembers() {
+        // given
+        val tester = createAndSaveMissionMember()
+        val mission = tester.mission.id?.let { missionRepository.findById(it) }?.get()
+
+        val contact = contactRepository.save(getContact("tester2@photi.com"))
+        val user = userRepository.save(getUser(contact, "tester2"))
+        val tester2 = mission?.let { MissionMember(user = user, mission = it, isCreator = false) }
+
+        val missionMember = tester2?.let { missionMemberRepository.save(it) }
+        val userId = missionMember?.user?.id
+        val missionId = missionMember?.mission?.id
+
+        // when
+        val result = userId?.let { uid ->
+            missionId?.let { mid ->
+                missionMemberRepository.findAllByMissionId(uid, mid)
+            }
+        }
+
+        // then
+        assertThat(result?.size).isEqualTo(2)
+    }
+
+    private fun getContact(email: String): Contact {
+        return Contact(email = email, verificationCode = "000000", verifyYn = true)
+    }
+
+    private fun getUser(contact: Contact, username: String): User {
+        return User(contact = contact, username = username, password = "password1!", imageUrl = "")
+    }
+
     private fun createAndSaveMissionMember(): MissionMember {
         val mission = createAndSaveMission()
-        val contact = contactRepository.save(
-            Contact(
-                email = "tester@photi.com",
-                verificationCode = "000000",
-                verifyYn = true
-            )
-        )
-        val user = userRepository.save(
-            User(
-                contact = contact,
-                username = "tester",
-                password = "password1!",
-                imageUrl = ""
-            )
-        )
-
+        val contact = contactRepository.save(getContact("tester@photi.com"))
+        val user = userRepository.save(getUser(contact, "tester"))
         return missionMemberRepository.save(MissionMember(user = user, mission = mission))
     }
 

--- a/src/test/kotlin/com/alloon/alloonserver/domain/mission/MissionMemberRepositoryTest.kt
+++ b/src/test/kotlin/com/alloon/alloonserver/domain/mission/MissionMemberRepositoryTest.kt
@@ -21,7 +21,6 @@ import java.time.LocalTime
 
 @ActiveProfiles("test")
 @SpringBootTest
-@Transactional
 @ContextConfiguration(initializers = [TestContainerInitializer::class])
 class MissionMemberRepositoryTest(
     @Autowired private val missionMemberRepository: MissionMemberRepository,
@@ -32,6 +31,7 @@ class MissionMemberRepositoryTest(
 
     @DisplayName("미션 멤버 식별자로 미션 멤버 조회가 정상 작동한다")
     @Test
+    @Transactional
     fun givenValid_whenFind_thenReturnTrue() {
         // given
         val missionMember = createAndSaveMissionMember()
@@ -45,6 +45,7 @@ class MissionMemberRepositoryTest(
 
     @DisplayName("사용자 id와 챌린지 id로 조회하면 일치하는 챌린지 멤버를 반환한다")
     @Test
+    @Transactional
     fun givenValid_whenFindByUserIdAndMissionId_thenReturnMissionMember() {
         // given
         val missionMember = createAndSaveMissionMember()

--- a/src/test/kotlin/com/alloon/alloonserver/service/mission/MissionServiceTest.kt
+++ b/src/test/kotlin/com/alloon/alloonserver/service/mission/MissionServiceTest.kt
@@ -5,17 +5,12 @@ import com.alloon.alloonserver.common.constant.ExceptionCode.MISSION_MEMBER_NOT_
 import com.alloon.alloonserver.common.constant.ExceptionCode.USER_NOT_FOUND
 import com.alloon.alloonserver.common.response.CustomException
 import com.alloon.alloonserver.domain.mission.*
-import com.alloon.alloonserver.service.mission.dto.FindPopularMissionsDto
 import com.alloon.alloonserver.domain.user.Contact
 import com.alloon.alloonserver.domain.user.User
 import com.alloon.alloonserver.domain.user.UserRepository
 import com.alloon.alloonserver.framework.AbstractMailProperties
 import com.alloon.alloonserver.framework.TestContainerInitializer
-import com.alloon.alloonserver.service.mission.dto.CreateMissionDto
-import com.alloon.alloonserver.service.mission.dto.CreateMissionHashtagDto
-import com.alloon.alloonserver.service.mission.dto.CreateMissionRuleDto
-import com.alloon.alloonserver.service.mission.dto.FindMissionInfoDto
-import com.alloon.alloonserver.service.mission.dto.UpdateMissionMemberGoalDto
+import com.alloon.alloonserver.service.mission.dto.*
 import com.alloon.alloonserver.service.s3.S3Service
 import io.mockk.every
 import io.mockk.mockk
@@ -226,6 +221,24 @@ class MissionServiceTest : AbstractMailProperties {
             .isInstanceOf(CustomException::class.java)
             .extracting("exceptionCode")
             .isEqualTo(MISSION_MEMBER_NOT_FOUND)
+    }
+
+    @DisplayName("챌린지 멤버가 챌린지 파티원 조회를 하면 일치하는 챌린지 멤버 리스트를 반환한다")
+    @Test
+    fun givenValid_whenFindMissionMembers_thenReturn() {
+        // given
+        val userId = 1L
+        val missionId = 1L
+        val dto = FindMissionMembersDto(1L, "tester", "", true, LocalDateTime.now(), "개인목표")
+
+        every { missionMemberRepository.findAllByMissionId(any(), any()) } returns listOf(dto)
+
+        // when
+        val result = missionService.findMissionMembers(userId, missionId)
+
+        // then
+        assertThat(result[0]).isEqualTo(dto)
+        assertThat(result.size).isEqualTo(1)
     }
 
     private fun getUser(): User {


### PR DESCRIPTION
## 📋 이슈 번호
- close #82 
  </br>

## 🛠 구현 사항
- 파티장 -> 본인 -> 가입순으로 정렬 (최하단이 최근 가입한 파티원)
- 파티원 수, 파티원 아이디, 파티장인지 파티원인지, 파티원 이미지, 활동 기간, 개인목표 조회
  </br>

## 📚 기타
- 
  </br>