### PR TITLE
[feature] 챌린지 예시 이미지 리스트 조회 API

### DIFF
--- a/src/main/kotlin/com/alloon/alloonserver/api/controller/challenge/ChallengeController.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/api/controller/challenge/ChallengeController.kt
@@ -24,7 +24,6 @@ import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.*
 import org.springframework.web.multipart.MultipartFile
 import java.security.Principal
-import java.time.LocalDateTime
 
 @Validated
 @RestController
@@ -32,21 +31,6 @@ import java.time.LocalDateTime
 class ChallengeController(
     private val challengeService: ChallengeService
 ) {
-
-    @GetMapping("/api/challenges/image/templates")
-    @Operation(summary = "챌린지 예시 이미지 리스트 조회")
-    @ApiResponses(
-        value = [
-            ApiResponse(responseCode = "200", description = "챌린지 예시 이미지 리스트 조회 성공"),
-            ApiResponse(responseCode = "401", description = "승인되지 않은 요청입니다. 다시 로그인 해주세요."),
-            ApiResponse(responseCode = "403", description = "권한이 없는 요청입니다. 로그인 후에 다시 시도 해주세요."),
-        ]
-    )
-    fun getAllChallengeTemplateImages(): ResponseEntity<DefaultListResponse<String>> {
-        val response = challengeService.getAllChallengeTemplateImages(LocalDateTime.now())
-
-        return DefaultListResponse.toResponseEntity(FOUND_CHALLENGE_TEMPLATE_IMAGES, response)
-    }
 
     @PostMapping("/api/challenges", consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
     @Operation(summary = "챌린지 생성", security = [SecurityRequirement(name = ACCESS_TOKEN_KEY)])
@@ -75,6 +59,15 @@ class ChallengeController(
         val response = CreateChallengeResponse.of(challenge)
 
         return DefaultSingleResponse.toResponseEntity(CHALLENGE_CREATED, response)
+    }
+
+    @GetMapping("/api/challenges/example-images")
+    @Operation(summary = "챌린지 예시 이미지 리스트 조회")
+    @ApiResponses(value = [ApiResponse(responseCode = "200", description = "챌린지 예시 이미지 리스트 조회 성공")])
+    fun getChallengeExampleImages(): ResponseEntity<DefaultListResponse<String>> {
+        val response = challengeService.getChallengeExampleImages()
+
+        return DefaultListResponse.toResponseEntity(FOUND_CHALLENGE_TEMPLATE_IMAGES, response)
     }
 
     @GetMapping("/api/challenges/popular")

--- a/src/main/kotlin/com/alloon/alloonserver/service/challenge/ChallengeService.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/service/challenge/ChallengeService.kt
@@ -10,14 +10,12 @@ import com.alloon.alloonserver.service.s3.S3Service
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.multipart.MultipartFile
-import java.time.LocalDateTime
 
 @Service
 @Transactional(readOnly = true)
 class ChallengeService(
     private val challengeRepository: ChallengeRepository,
     private val challengeMemberRepository: ChallengeMemberRepository,
-    private val challengeTemplateImageRepository: ChallengeTemplateImageRepository,
     private val userRepository: UserRepository,
     private val s3Service: S3Service,
 ) {
@@ -41,8 +39,8 @@ class ChallengeService(
         return CreateChallengeDto.of(challenge)
     }
 
-    fun getAllChallengeTemplateImages(now: LocalDateTime): List<String> {
-        return challengeTemplateImageRepository.findAllImageUrl(now)
+    fun getChallengeExampleImages(): List<String> {
+        return s3Service.getChallengeExampleImages()
     }
 
     fun findPopularChallenges(): List<FindPopularChallengesDto> {

--- a/src/main/kotlin/com/alloon/alloonserver/service/s3/FolderType.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/service/s3/FolderType.kt
@@ -1,5 +1,5 @@
 package com.alloon.alloonserver.service.s3
 
 enum class FolderType {
-    USERS, CHALLENGES
+    USERS, CHALLENGES, CHALLENGE_EXAMPLES
 }

--- a/src/main/kotlin/com/alloon/alloonserver/service/s3/S3Service.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/service/s3/S3Service.kt
@@ -4,6 +4,7 @@ import com.alloon.alloonserver.common.constant.ExceptionCode.SERVER_ERROR
 import com.alloon.alloonserver.common.response.CustomException
 import com.alloon.alloonserver.common.util.createFileName
 import com.alloon.alloonserver.common.util.validateFile
+import com.alloon.alloonserver.service.s3.FolderType.*
 import com.amazonaws.services.s3.AmazonS3Client
 import com.amazonaws.services.s3.model.CannedAccessControlList.PublicRead
 import com.amazonaws.services.s3.model.ObjectMetadata
@@ -50,10 +51,19 @@ class S3Service(private val amazonS3Client: AmazonS3Client) {
         return amazonS3Client.getUrl(bucket, fileName).toString()
     }
 
+    fun getChallengeExampleImages(): List<String> {
+        return amazonS3Client.listObjects(bucket, getRoot(CHALLENGE_EXAMPLES))
+            .objectSummaries
+            .map { it.key }
+            .filter { it.endsWith(".jpg") }
+            .map { getImageUrl(it) }
+    }
+
     private fun getRoot(folderType: FolderType): String {
         return when (folderType) {
-            FolderType.USERS -> userFolder
-            FolderType.CHALLENGES -> challengeFolder
+            USERS -> userFolder
+            CHALLENGES -> challengeFolder
+            CHALLENGE_EXAMPLES -> challengeFolder + "examples"
         }
     }
 }

--- a/src/test/kotlin/com/alloon/alloonserver/api/controller/challenge/ChallengeControllerTest.kt
+++ b/src/test/kotlin/com/alloon/alloonserver/api/controller/challenge/ChallengeControllerTest.kt
@@ -31,23 +31,6 @@ class ChallengeControllerTest : RestDocsSupport() {
         return ChallengeController(challengeService)
     }
 
-    @DisplayName("챌린지 예시 이미지 전체 조회를 하면 200을 반환한다")
-    @Test
-    fun givenValid_whenGetAllChallengeTemplateImages_thenReturn200() {
-        // given
-        every { challengeService.getAllChallengeTemplateImages(any()) } returns listOf("https://alloon.s3.us-east-2.amazonaws.com/alloon-logo.png")
-
-        // when
-        val resultActions = mockMvc.perform(
-            get("/api/challenges/image/templates")
-                .header(AUTHORIZATION, "Bearer access-token")
-                .principal(mockPrincipal)
-        )
-
-        // then
-        resultActions.andExpect(status().isOk)
-    }
-
     @DisplayName("챌린지 생성을 하면 201을 반환한다")
     @Test
     fun givenValid_whenCreateChallenge_thenReturn201() {
@@ -78,6 +61,19 @@ class ChallengeControllerTest : RestDocsSupport() {
         // then
         resultActions.andExpect(status().isCreated)
             .andExpect(jsonPath("$.message").value("챌린지 생성이 완료되었습니다."))
+    }
+
+    @DisplayName("챌린지 예시 이미지 전체 조회를 하면 200을 반환한다")
+    @Test
+    fun givenValid_whenGetChallengeExampleImages_thenReturn200() {
+        // given
+        every { challengeService.getChallengeExampleImages() } returns listOf("https://url.kr/5MhHhD")
+
+        // when
+        val resultActions = mockMvc.perform(get("/api/challenges/example-images"))
+
+        // then
+        resultActions.andExpect(status().isOk)
     }
 
     @DisplayName("챌린지가 있는 경우 지금 인기있는 챌린지 조회를 하면 200을 반환한다")

--- a/src/test/kotlin/com/alloon/alloonserver/service/challenge/ChallengeServiceTest.kt
+++ b/src/test/kotlin/com/alloon/alloonserver/service/challenge/ChallengeServiceTest.kt
@@ -31,14 +31,12 @@ class ChallengeServiceTest : AbstractMailProperties {
 
     private val challengeRepository = mockk<ChallengeRepository>()
     private val challengeMemberRepository = mockk<ChallengeMemberRepository>()
-    private val challengeTemplateImageRepository = mockk<ChallengeTemplateImageRepository>()
     private val userRepository = mockk<UserRepository>()
     private val s3Service = mockk<S3Service>()
 
     private val challengeService = ChallengeService(
         challengeRepository,
         challengeMemberRepository,
-        challengeTemplateImageRepository,
         userRepository,
         s3Service
     )
@@ -84,20 +82,17 @@ class ChallengeServiceTest : AbstractMailProperties {
             .isEqualTo(USER_NOT_FOUND)
     }
 
-    @DisplayName("챌린 예시 이미지 전체 조회가 정상 작동한다")
+    @DisplayName("챌린지 예시 이미지 전체 조회가 정상 작동한다")
     @Test
-    fun givenValid_whenGetAllChallengeTemplateImages_thenReturn() {
+    fun givenValid_whenGetChallengeExampleImages_thenReturn() {
         // given
-        val now = LocalDateTime.now()
-        val challengeTemplateImage = getChallengeTemplateImage(now)
-
-        every { challengeTemplateImageRepository.findAllImageUrl(any()) } returns mutableListOf("image")
+        every { s3Service.getChallengeExampleImages() } returns listOf("https://url.kr/5MhHhD")
 
         // when
-        val response = challengeService.getAllChallengeTemplateImages(now)
+        val response = challengeService.getChallengeExampleImages()
 
         // then
-        assertThat(response).containsExactly(challengeTemplateImage.imageUrl)
+        assertThat(response.size).isEqualTo(1)
     }
 
     @DisplayName("지금 인기있는 챌린지 조회가 정상 작동한다")
@@ -234,15 +229,6 @@ class ChallengeServiceTest : AbstractMailProperties {
                 CreateChallengeHashtagDto("해시태그 2"),
             ),
             imageUrl = "https://url.kr/5MhHhD"
-        )
-    }
-
-    private fun getChallengeTemplateImage(now: LocalDateTime): ChallengeTemplateImage {
-        return ChallengeTemplateImage(
-            imageUrl = "image",
-            startDateTime = now.minusSeconds(1),
-            endDateTime = now.plusSeconds(1),
-            admin = null
         )
     }
 


### PR DESCRIPTION
## 📋 이슈 번호
- close #91 
  </br>

## 🛠 구현 사항
- s3에 예시 이미지 6개 업로드
- s3에서 예시 이미지 url 리스트 불러오기
  </br>

## 📚 기타
- 
  </br>