### PR TITLE
[docs] Swagger 수정

### DIFF
--- a/src/main/kotlin/com/alloon/alloonserver/api/controller/challenge/ChallengeController.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/api/controller/challenge/ChallengeController.kt
@@ -6,18 +6,20 @@ import com.alloon.alloonserver.api.controller.challenge.response.CreateChallenge
 import com.alloon.alloonserver.api.controller.challenge.response.FindChallengeInfoResponse
 import com.alloon.alloonserver.api.controller.challenge.response.FindChallengeMembersResponse
 import com.alloon.alloonserver.api.controller.challenge.response.FindPopularChallengesResponse
-import com.alloon.alloonserver.common.constant.SuccessCode.*
-import com.alloon.alloonserver.common.response.*
+import com.alloon.alloonserver.common.constant.ExceptionCode.*
+import com.alloon.alloonserver.common.response.ApiErrorResponses
+import com.alloon.alloonserver.common.response.CollectionSuccessResponse
+import com.alloon.alloonserver.common.response.StringSuccessResponse
 import com.alloon.alloonserver.common.util.UserUtility
 import com.alloon.alloonserver.config.SwaggerConfig.Companion.ACCESS_TOKEN_KEY
 import com.alloon.alloonserver.service.challenge.ChallengeService
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.responses.ApiResponse
-import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
+import org.springframework.http.HttpStatus.CREATED
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.validation.annotation.Validated
@@ -34,23 +36,13 @@ class ChallengeController(
 
     @PostMapping("/api/challenges", consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
     @Operation(summary = "챌린지 생성", security = [SecurityRequirement(name = ACCESS_TOKEN_KEY)])
-    @ApiResponses(
-        value = [
-            ApiResponse(responseCode = "201", description = "챌린지 생성 성공"),
-            ApiResponse(responseCode = "401", description = "승인되지 않은 요청입니다. 다시 로그인 해주세요."),
-            ApiResponse(responseCode = "403", description = "권한이 없는 요청입니다. 로그인 후에 다시 시도 해주세요."),
-            ApiResponse(responseCode = "404", description = "존재하지 않는 회원입니다."),
-            ApiResponse(
-                responseCode = "415",
-                description = "이미지는 '.jpeg', '.jpg', '.png', '.gif' 타입만 가능합니다."
-            ),
-        ]
-    )
+    @ApiResponse(responseCode = "201")
+    @ApiErrorResponses([EMPTY_FILE_INVALID, TOKEN_UNAUTHENTICATED, TOKEN_UNAUTHORIZED, USER_NOT_FOUND, IMAGE_TYPE_UNSUPPORTED])
     fun createChallenge(
         principal: Principal,
         @RequestPart @Valid request: CreateChallengeRequest,
         @RequestPart imageFile: MultipartFile
-    ): ResponseEntity<DefaultSingleResponse> {
+    ): ResponseEntity<CreateChallengeResponse> {
         val challenge = challengeService.createChallenge(
             UserUtility.getUserId(principal),
             request.toServiceDto(),
@@ -58,16 +50,16 @@ class ChallengeController(
         )
         val response = CreateChallengeResponse.of(challenge)
 
-        return DefaultSingleResponse.toResponseEntity(CHALLENGE_CREATED, response)
+        return ResponseEntity.status(CREATED).body(response)
     }
 
     @GetMapping("/api/challenges/example-images")
     @Operation(summary = "챌린지 예시 이미지 리스트 조회")
-    @ApiResponses(value = [ApiResponse(responseCode = "200", description = "챌린지 예시 이미지 리스트 조회 성공")])
-    fun getChallengeExampleImages(): ResponseEntity<DefaultListResponse<String>> {
+    @ApiResponse(responseCode = "200")
+    fun getChallengeExampleImages(): ResponseEntity<CollectionSuccessResponse> {
         val response = challengeService.getChallengeExampleImages()
 
-        return DefaultListResponse.toResponseEntity(FOUND_CHALLENGE_TEMPLATE_IMAGES, response)
+        return ResponseEntity.ok(CollectionSuccessResponse(response))
     }
 
     @GetMapping("/api/challenges/popular")
@@ -75,56 +67,43 @@ class ChallengeController(
         summary = "지금 인기있는 챌린지 조회",
         description = "공개, 비공개 및 종료되지 않은 챌린지가 방문순으로 최대 5개 조회됩니다."
     )
-    @ApiResponses(value = [ApiResponse(responseCode = "200", description = "지금 인기있는 챌린지 조회 성공")])
-    fun findPopularChallenges(): ResponseEntity<DefaultListResponse<FindPopularChallengesResponse>> {
+    @ApiResponse(responseCode = "200")
+    fun findPopularChallenges(): ResponseEntity<List<FindPopularChallengesResponse>> {
         val response = FindPopularChallengesResponse.of(challengeService.findPopularChallenges())
-        val successCode =
-            if (response.isNotEmpty()) FOUND_POPULAR_CHALLENGES else NO_POPULAR_CHALLENGES
 
-        return DefaultListResponse.toResponseEntity(successCode, response)
+        return ResponseEntity.ok(response)
     }
 
     @GetMapping("/api/challenges/{challengeId}/info")
     @Operation(summary = "챌린지 소개 조회", security = [SecurityRequirement(name = ACCESS_TOKEN_KEY)])
-    @ApiResponses(
-        value = [
-            ApiResponse(responseCode = "200", description = "챌린지 소개 조회 성공"),
-            ApiResponse(responseCode = "401", description = "승인되지 않은 요청입니다. 다시 로그인 해주세요."),
-            ApiResponse(responseCode = "403", description = "권한이 없는 요청입니다. 로그인 후에 다시 시도 해주세요."),
-            ApiResponse(responseCode = "404", description = "존재하지 않는 챌린지입니다."),
-        ]
-    )
+    @ApiResponse(responseCode = "200")
+    @ApiErrorResponses([TOKEN_UNAUTHENTICATED, TOKEN_UNAUTHORIZED, CHALLENGE_NOT_FOUND])
     fun findChallengeInfo(
         principal: Principal,
-        @PathVariable challengeId: Long
-    ): ResponseEntity<DefaultSingleResponse> {
+        @PathVariable @Parameter(description = "챌린지 id", example = "1") challengeId: Long
+    ): ResponseEntity<FindChallengeInfoResponse> {
         val challengeInfo = challengeService.findChallengeInfo(challengeId)
         val response = FindChallengeInfoResponse.of(challengeInfo)
-        return DefaultSingleResponse.toResponseEntity(FOUND_CHALLENGE_INFO, response)
+
+        return ResponseEntity.ok(response)
     }
 
     @PatchMapping("/api/challenges/{challengeId}/challenge-members/goal")
     @Operation(summary = "챌린지 개인목표 작성", security = [SecurityRequirement(name = ACCESS_TOKEN_KEY)])
-    @ApiResponses(
-        value = [
-            ApiResponse(responseCode = "200", description = "챌린지 개인목표 작성 성공"),
-            ApiResponse(responseCode = "401", description = "승인되지 않은 요청입니다. 다시 로그인 해주세요."),
-            ApiResponse(responseCode = "403", description = "권한이 없는 요청입니다. 로그인 후에 다시 시도 해주세요."),
-            ApiResponse(responseCode = "404", description = "존재하지 않는 챌린지 파티원입니다."),
-        ]
-    )
+    @ApiResponse(responseCode = "200")
+    @ApiErrorResponses([TOKEN_UNAUTHENTICATED, TOKEN_UNAUTHORIZED, CHALLENGE_MEMBER_NOT_FOUND])
     fun updateChallengeMemberGoal(
         principal: Principal,
         @PathVariable @Parameter(description = "챌린지 id", example = "1") challengeId: Long,
         @RequestBody @Valid request: UpdateChallengeMemberGoalRequest,
-    ): ResponseEntity<DefaultResponse> {
+    ): ResponseEntity<StringSuccessResponse> {
         challengeService.updateChallengeMemberGoal(
             UserUtility.getUserId(principal),
             challengeId,
             request.toServiceDto()
         )
 
-        return DefaultResponse.toResponseEntity(CHALLENGE_MEMBER_GOAL_UPDATED)
+        return ResponseEntity.ok(StringSuccessResponse("챌린지 개인목표 작성이 완료되었습니다."))
     }
 
     @GetMapping("/api/challenges/{challengeId}/challenge-members")
@@ -133,23 +112,16 @@ class ChallengeController(
         description = "파티장 -> 본인 -> 가입순으로 파티원이 전체 조회됩니다.",
         security = [SecurityRequirement(name = ACCESS_TOKEN_KEY)]
     )
-    @ApiResponses(
-        value = [
-            ApiResponse(responseCode = "200", description = "챌린지 파티원 조회 성공"),
-            ApiResponse(responseCode = "401", description = "승인되지 않은 요청입니다. 다시 로그인 해주세요."),
-            ApiResponse(responseCode = "403", description = "권한이 없는 요청입니다. 로그인 후에 다시 시도 해주세요."),
-        ]
-    )
+    @ApiResponse(responseCode = "200")
+    @ApiErrorResponses([TOKEN_UNAUTHENTICATED, TOKEN_UNAUTHORIZED])
     fun findChallengeMembers(
         principal: Principal,
         @PathVariable @Parameter(description = "챌린지 id", example = "1") challengeId: Long,
-    ): ResponseEntity<DefaultPageResponse<FindChallengeMembersResponse>> {
+    ): ResponseEntity<List<FindChallengeMembersResponse>> {
         val challengeMembers =
             challengeService.findChallengeMembers(UserUtility.getUserId(principal), challengeId)
         val response = FindChallengeMembersResponse.of(challengeMembers)
-        return DefaultPageResponse.toResponseEntity(
-            FOUND_CHALLENGE_MEMBERS,
-            PageData(response, response.size.toLong())
-        )
+
+        return ResponseEntity.ok(response)
     }
 }

--- a/src/main/kotlin/com/alloon/alloonserver/api/controller/user/AuthController.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/api/controller/user/AuthController.kt
@@ -4,7 +4,7 @@ import com.alloon.alloonserver.api.controller.user.request.*
 import com.alloon.alloonserver.common.constant.ExceptionCode.*
 import com.alloon.alloonserver.common.constant.RegexPatternConstants.Companion.LOWERCASE_NUMBER_UNDERSCORE
 import com.alloon.alloonserver.common.response.ApiErrorResponses
-import com.alloon.alloonserver.common.response.StringResponse
+import com.alloon.alloonserver.common.response.StringSuccessResponse
 import com.alloon.alloonserver.common.util.UserUtility
 import com.alloon.alloonserver.config.SwaggerConfig.Companion.ACCESS_TOKEN_KEY
 import com.alloon.alloonserver.config.SwaggerConfig.Companion.REFRESH_TOKEN_KEY
@@ -41,21 +41,21 @@ class AuthController(
     @Operation(summary = "이메일 인증코드 전송")
     @ApiResponse(responseCode = "201")
     @ApiErrorResponses([EXISTING_EMAIL])
-    fun sendVerificationCode(@RequestBody @Valid request: ContactSendVerificationRequest): ResponseEntity<StringResponse> {
+    fun sendVerificationCode(@RequestBody @Valid request: ContactSendVerificationRequest): ResponseEntity<StringSuccessResponse> {
         authService.sendVerificationCode(request.toServiceDto())
 
         return ResponseEntity.status(CREATED)
-            .body(StringResponse("이메일 인증코드를 보냈습니다."))
+            .body(StringSuccessResponse("이메일 인증코드를 보냈습니다."))
     }
 
     @PatchMapping("/api/contacts/verify")
     @Operation(summary = "이메일 인증코드 확인")
     @ApiResponse(responseCode = "200")
     @ApiErrorResponses([EMAIL_VERIFICATION_CODE_INVALID, EMAIL_NOT_FOUND])
-    fun verifyEmailVerificationCode(@RequestBody @Valid request: ContactVerifyRequest): ResponseEntity<StringResponse> {
+    fun verifyEmailVerificationCode(@RequestBody @Valid request: ContactVerifyRequest): ResponseEntity<StringSuccessResponse> {
         authService.verifyEmailVerificationCode(request.toServiceDto())
 
-        return ResponseEntity.ok(StringResponse("이메일 인증코드가 확인 되었습니다."))
+        return ResponseEntity.ok(StringSuccessResponse("이메일 인증코드가 확인 되었습니다."))
     }
 
     @GetMapping("/api/users/username")
@@ -67,10 +67,10 @@ class AuthController(
         @Pattern(regexp = LOWERCASE_NUMBER_UNDERSCORE)
         @Parameter(description = "아이디", example = "photi_123")
         username: String
-    ): ResponseEntity<StringResponse> {
+    ): ResponseEntity<StringSuccessResponse> {
         authService.validateUsername(UserServiceValidateUsernameDto(username))
 
-        return ResponseEntity.ok(StringResponse("사용 가능한 아이디입니다."))
+        return ResponseEntity.ok(StringSuccessResponse("사용 가능한 아이디입니다."))
     }
 
     @PostMapping("/api/users/register")
@@ -88,20 +88,20 @@ class AuthController(
     @Operation(summary = "아이디 찾기")
     @ApiResponse(responseCode = "200")
     @ApiErrorResponses([USER_NOT_FOUND])
-    fun findUsername(@RequestBody @Valid request: UserFindUsernameRequest): ResponseEntity<StringResponse> {
+    fun findUsername(@RequestBody @Valid request: UserFindUsernameRequest): ResponseEntity<StringSuccessResponse> {
         authService.findUsername(request.toServiceDto())
 
-        return ResponseEntity.ok(StringResponse("아이디를 이메일로 전송했습니다."))
+        return ResponseEntity.ok(StringSuccessResponse("아이디를 이메일로 전송했습니다."))
     }
 
     @PostMapping("/api/users/find-password")
     @Operation(summary = "비밀번호 찾기")
     @ApiResponse(responseCode = "200")
     @ApiErrorResponses([USER_NOT_FOUND])
-    fun findPassword(@RequestBody @Valid request: UserFindPasswordRequest): ResponseEntity<StringResponse> {
+    fun findPassword(@RequestBody @Valid request: UserFindPasswordRequest): ResponseEntity<StringSuccessResponse> {
         authService.findPassword(request.toServiceDto())
 
-        return ResponseEntity.ok(StringResponse("임시 비밀번호를 이메일로 전송했습니다."))
+        return ResponseEntity.ok(StringSuccessResponse("임시 비밀번호를 이메일로 전송했습니다."))
     }
 
     @PostMapping("/api/users/login")
@@ -122,21 +122,21 @@ class AuthController(
     fun changePassword(
         principal: Principal,
         @RequestBody @Valid request: UserChangePasswordRequest
-    ): ResponseEntity<StringResponse> {
+    ): ResponseEntity<StringSuccessResponse> {
         authService.changePassword(UserUtility.getUserId(principal), request.toServiceDto())
 
-        return ResponseEntity.ok(StringResponse("비밀번호가 변경되었습니다."))
+        return ResponseEntity.ok(StringSuccessResponse("비밀번호가 변경되었습니다."))
     }
 
     @PostMapping("/api/users/token")
     @Operation(summary = "토큰 재발급", security = [SecurityRequirement(name = REFRESH_TOKEN_KEY)])
     @ApiResponse(responseCode = "200")
     @ApiErrorResponses([TOKEN_UNAUTHENTICATED, TOKEN_UNAUTHORIZED])
-    fun refreshToken(principal: Principal): ResponseEntity<StringResponse> {
+    fun refreshToken(principal: Principal): ResponseEntity<StringSuccessResponse> {
         val headers = jwtProvider.createToken(UserUtility.getUserId(principal))
 
         return ResponseEntity.status(OK)
             .headers(headers)
-            .body(StringResponse("토큰이 재발급 됐습니다."))
+            .body(StringSuccessResponse("토큰이 재발급 됐습니다."))
     }
 }

--- a/src/main/kotlin/com/alloon/alloonserver/api/controller/user/AuthController.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/api/controller/user/AuthController.kt
@@ -2,15 +2,15 @@ package com.alloon.alloonserver.api.controller.user
 
 import com.alloon.alloonserver.api.controller.user.request.*
 import com.alloon.alloonserver.common.constant.RegexPatternConstants
-import com.alloon.alloonserver.common.constant.SuccessCode.*
-import com.alloon.alloonserver.common.response.DefaultResponse
-import com.alloon.alloonserver.common.response.DefaultSingleResponse
+import com.alloon.alloonserver.common.response.StringResponse
 import com.alloon.alloonserver.common.util.UserUtility
 import com.alloon.alloonserver.config.SwaggerConfig.Companion.ACCESS_TOKEN_KEY
 import com.alloon.alloonserver.config.SwaggerConfig.Companion.REFRESH_TOKEN_KEY
 import com.alloon.alloonserver.config.auth.JwtProvider
 import com.alloon.alloonserver.service.user.AuthService
 import com.alloon.alloonserver.service.user.dto.UserServiceValidateUsernameDto
+import com.alloon.alloonserver.service.user.response.UserLoginResponse
+import com.alloon.alloonserver.service.user.response.UserRegisterResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.responses.ApiResponse
@@ -21,6 +21,8 @@ import jakarta.validation.Valid
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.Pattern
 import jakarta.validation.constraints.Size
+import org.springframework.http.HttpStatus.CREATED
+import org.springframework.http.HttpStatus.OK
 import org.springframework.http.ResponseEntity
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.*
@@ -42,10 +44,11 @@ class AuthController(
             ApiResponse(responseCode = "409", description = "이미 사용중인 이메일입니다."),
         ]
     )
-    fun sendVerificationCode(@RequestBody @Valid request: ContactSendVerificationRequest): ResponseEntity<DefaultResponse> {
+    fun sendVerificationCode(@RequestBody @Valid request: ContactSendVerificationRequest): ResponseEntity<StringResponse> {
         authService.sendVerificationCode(request.toServiceDto())
 
-        return DefaultResponse.toResponseEntity(EMAIL_VERIFICATION_CODE_SENT)
+        return ResponseEntity.status(CREATED)
+            .body(StringResponse("이메일 인증코드를 보냈습니다."))
     }
 
     @PatchMapping("/api/contacts/verify")
@@ -57,10 +60,10 @@ class AuthController(
             ApiResponse(responseCode = "404", description = "존재하지 않는 이메일입니다."),
         ]
     )
-    fun verifyEmailVerificationCode(@RequestBody @Valid request: ContactVerifyRequest): ResponseEntity<DefaultResponse> {
+    fun verifyEmailVerificationCode(@RequestBody @Valid request: ContactVerifyRequest): ResponseEntity<StringResponse> {
         authService.verifyEmailVerificationCode(request.toServiceDto())
 
-        return DefaultResponse.toResponseEntity(EMAIL_VERIFICATION_CODE_VERIFIED)
+        return ResponseEntity.ok(StringResponse("이메일 인증코드가 확인 되었습니다."))
     }
 
     @GetMapping("/api/users/username")
@@ -86,10 +89,10 @@ class AuthController(
         )
         @Parameter(description = "아이디", example = "photi_123")
         username: String
-    ): ResponseEntity<DefaultResponse> {
+    ): ResponseEntity<StringResponse> {
         authService.validateUsername(UserServiceValidateUsernameDto(username))
 
-        return DefaultResponse.toResponseEntity(USERNAME_AVAILABLE)
+        return ResponseEntity.ok(StringResponse("사용 가능한 아이디입니다."))
     }
 
     @PostMapping("/api/users/register")
@@ -114,12 +117,11 @@ class AuthController(
             ),
         ]
     )
-    fun registerUser(@RequestBody @Valid request: UserRegisterRequest): ResponseEntity<DefaultSingleResponse> {
+    fun registerUser(@RequestBody @Valid request: UserRegisterRequest): ResponseEntity<UserRegisterResponse> {
         val response = authService.registerUser(request.toServiceDto())
-
         val headers = jwtProvider.createToken(response.userId)
 
-        return DefaultSingleResponse.toResponseEntity(headers, USER_REGISTERED, response)
+        return ResponseEntity.status(CREATED).headers(headers).body(response)
     }
 
     @PostMapping("/api/users/find-username")
@@ -130,10 +132,10 @@ class AuthController(
             ApiResponse(responseCode = "404", description = "존재하지 않는 회원입니다."),
         ]
     )
-    fun findUsername(@RequestBody @Valid request: UserFindUsernameRequest): ResponseEntity<DefaultResponse> {
+    fun findUsername(@RequestBody @Valid request: UserFindUsernameRequest): ResponseEntity<StringResponse> {
         authService.findUsername(request.toServiceDto())
 
-        return DefaultResponse.toResponseEntity(USERNAME_SENT)
+        return ResponseEntity.ok(StringResponse("아이디를 이메일로 전송했습니다."))
     }
 
     @PostMapping("/api/users/find-password")
@@ -144,10 +146,10 @@ class AuthController(
             ApiResponse(responseCode = "404", description = "존재하지 않는 회원입니다."),
         ]
     )
-    fun findPassword(@RequestBody @Valid request: UserFindPasswordRequest): ResponseEntity<DefaultResponse> {
+    fun findPassword(@RequestBody @Valid request: UserFindPasswordRequest): ResponseEntity<StringResponse> {
         authService.findPassword(request.toServiceDto())
 
-        return DefaultResponse.toResponseEntity(PASSWORD_SENT)
+        return ResponseEntity.ok(StringResponse("임시 비밀번호를 이메일로 전송했습니다."))
     }
 
     @PostMapping("/api/users/login")
@@ -158,12 +160,11 @@ class AuthController(
             ApiResponse(responseCode = "401", description = "아이디 또는 비밀번호가 틀렸습니다."),
         ]
     )
-    fun login(@RequestBody @Valid request: UserLoginRequest): ResponseEntity<DefaultSingleResponse> {
+    fun login(@RequestBody @Valid request: UserLoginRequest): ResponseEntity<UserLoginResponse> {
         val response = authService.login(request.toServiceDto())
-
         val headers = jwtProvider.createToken(response.userId)
 
-        return DefaultSingleResponse.toResponseEntity(headers, USER_LOGIN, response)
+        return ResponseEntity.status(OK).headers(headers).body(response)
     }
 
     @PatchMapping("/api/users/password")
@@ -185,10 +186,10 @@ class AuthController(
     fun changePassword(
         principal: Principal,
         @RequestBody @Valid request: UserChangePasswordRequest
-    ): ResponseEntity<DefaultResponse> {
+    ): ResponseEntity<StringResponse> {
         authService.changePassword(UserUtility.getUserId(principal), request.toServiceDto())
 
-        return DefaultResponse.toResponseEntity(PASSWORD_CHANGED)
+        return ResponseEntity.ok(StringResponse("비밀번호가 변경되었습니다."))
     }
 
     @PostMapping("/api/users/token")
@@ -200,9 +201,11 @@ class AuthController(
             ApiResponse(responseCode = "403", description = "권한이 없는 요청입니다. 로그인 후에 다시 시도 해주세요."),
         ]
     )
-    fun refreshToken(principal: Principal): ResponseEntity<DefaultResponse> {
+    fun refreshToken(principal: Principal): ResponseEntity<StringResponse> {
         val headers = jwtProvider.createToken(UserUtility.getUserId(principal))
 
-        return DefaultResponse.toResponseEntity(headers, TOKEN_REFRESHED)
+        return ResponseEntity.status(OK)
+            .headers(headers)
+            .body(StringResponse("토큰이 재발급 됐습니다."))
     }
 }

--- a/src/main/kotlin/com/alloon/alloonserver/api/controller/user/AuthController.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/api/controller/user/AuthController.kt
@@ -1,7 +1,9 @@
 package com.alloon.alloonserver.api.controller.user
 
 import com.alloon.alloonserver.api.controller.user.request.*
-import com.alloon.alloonserver.common.constant.RegexPatternConstants
+import com.alloon.alloonserver.common.constant.ExceptionCode.*
+import com.alloon.alloonserver.common.constant.RegexPatternConstants.Companion.LOWERCASE_NUMBER_UNDERSCORE
+import com.alloon.alloonserver.common.response.ApiErrorResponses
 import com.alloon.alloonserver.common.response.StringResponse
 import com.alloon.alloonserver.common.util.UserUtility
 import com.alloon.alloonserver.config.SwaggerConfig.Companion.ACCESS_TOKEN_KEY
@@ -14,7 +16,6 @@ import com.alloon.alloonserver.service.user.response.UserRegisterResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.responses.ApiResponse
-import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
@@ -38,12 +39,8 @@ class AuthController(
 
     @PostMapping("/api/contacts")
     @Operation(summary = "이메일 인증코드 전송")
-    @ApiResponses(
-        value = [
-            ApiResponse(responseCode = "201", description = "이메일 인증코드 전송 성공"),
-            ApiResponse(responseCode = "409", description = "이미 사용중인 이메일입니다."),
-        ]
-    )
+    @ApiResponse(responseCode = "201")
+    @ApiErrorResponses([EXISTING_EMAIL])
     fun sendVerificationCode(@RequestBody @Valid request: ContactSendVerificationRequest): ResponseEntity<StringResponse> {
         authService.sendVerificationCode(request.toServiceDto())
 
@@ -53,13 +50,8 @@ class AuthController(
 
     @PatchMapping("/api/contacts/verify")
     @Operation(summary = "이메일 인증코드 확인")
-    @ApiResponses(
-        value = [
-            ApiResponse(responseCode = "200", description = "이메일 인증코드 확인 성공"),
-            ApiResponse(responseCode = "400", description = "이메일 인증코드가 틀렸습니다."),
-            ApiResponse(responseCode = "404", description = "존재하지 않는 이메일입니다."),
-        ]
-    )
+    @ApiResponse(responseCode = "200")
+    @ApiErrorResponses([EMAIL_VERIFICATION_CODE_INVALID, EMAIL_NOT_FOUND])
     fun verifyEmailVerificationCode(@RequestBody @Valid request: ContactVerifyRequest): ResponseEntity<StringResponse> {
         authService.verifyEmailVerificationCode(request.toServiceDto())
 
@@ -68,25 +60,11 @@ class AuthController(
 
     @GetMapping("/api/users/username")
     @Operation(summary = "아이디 검증")
-    @ApiResponses(
-        value = [
-            ApiResponse(responseCode = "200", description = "아이디 검증 성공"),
-            ApiResponse(
-                responseCode = "409",
-                description = """
-                1. 사용 불가능한 아이디입니다.
-                2. 이미 사용중인 아이디입니다.
-                """
-            ),
-        ]
-    )
+    @ApiResponse(responseCode = "200")
+    @ApiErrorResponses([USERNAME_FORMAT_INVALID, UNAVAILABLE_USERNAME, EXISTING_USERNAME])
     fun validateUsername(
-        @RequestParam("username") @NotBlank(message = "아이디는 필수 입력입니다.")
-        @Size(min = 5, max = 20, message = "아이디는 5~20자만 가능합니다.")
-        @Pattern(
-            regexp = RegexPatternConstants.LOWERCASE_NUMBER_UNDERSCORE,
-            message = "아이디는 소문자 영어, 숫자, 특수문자(_)의 조합으로 입력해 주세요."
-        )
+        @RequestParam @NotBlank @Size(min = 5, max = 20)
+        @Pattern(regexp = LOWERCASE_NUMBER_UNDERSCORE)
         @Parameter(description = "아이디", example = "photi_123")
         username: String
     ): ResponseEntity<StringResponse> {
@@ -97,26 +75,8 @@ class AuthController(
 
     @PostMapping("/api/users/register")
     @Operation(summary = "회원가입")
-    @ApiResponses(
-        value = [
-            ApiResponse(responseCode = "201", description = "회원가입 성공"),
-            ApiResponse(
-                responseCode = "400",
-                description = """
-                1. 이메일 인증을 먼저 해주세요.
-                2. 비밀번호와 비밀번호 재입력이 동일하지 않습니다.
-                """
-            ),
-            ApiResponse(
-                responseCode = "409",
-                description = """
-                1. 해당 이메일로 이미 가입된 회원이 있습니다.
-                2. 사용 불가능한 아이디입니다.
-                3. 이미 사용중인 아이디입니다.
-                """
-            ),
-        ]
-    )
+    @ApiResponse(responseCode = "201")
+    @ApiErrorResponses([EMAIL_VALIDATION_INVALID, PASSWORD_MATCH_INVALID, EXISTING_USER, UNAVAILABLE_USERNAME, EXISTING_USERNAME])
     fun registerUser(@RequestBody @Valid request: UserRegisterRequest): ResponseEntity<UserRegisterResponse> {
         val response = authService.registerUser(request.toServiceDto())
         val headers = jwtProvider.createToken(response.userId)
@@ -126,12 +86,8 @@ class AuthController(
 
     @PostMapping("/api/users/find-username")
     @Operation(summary = "아이디 찾기")
-    @ApiResponses(
-        value = [
-            ApiResponse(responseCode = "200", description = "아이디 찾기 성공"),
-            ApiResponse(responseCode = "404", description = "존재하지 않는 회원입니다."),
-        ]
-    )
+    @ApiResponse(responseCode = "200")
+    @ApiErrorResponses([USER_NOT_FOUND])
     fun findUsername(@RequestBody @Valid request: UserFindUsernameRequest): ResponseEntity<StringResponse> {
         authService.findUsername(request.toServiceDto())
 
@@ -140,12 +96,8 @@ class AuthController(
 
     @PostMapping("/api/users/find-password")
     @Operation(summary = "비밀번호 찾기")
-    @ApiResponses(
-        value = [
-            ApiResponse(responseCode = "200", description = "비밀번호 찾기 성공"),
-            ApiResponse(responseCode = "404", description = "존재하지 않는 회원입니다."),
-        ]
-    )
+    @ApiResponse(responseCode = "200")
+    @ApiErrorResponses([USER_NOT_FOUND])
     fun findPassword(@RequestBody @Valid request: UserFindPasswordRequest): ResponseEntity<StringResponse> {
         authService.findPassword(request.toServiceDto())
 
@@ -154,12 +106,8 @@ class AuthController(
 
     @PostMapping("/api/users/login")
     @Operation(summary = "로그인")
-    @ApiResponses(
-        value = [
-            ApiResponse(responseCode = "200", description = "로그인 성공"),
-            ApiResponse(responseCode = "401", description = "아이디 또는 비밀번호가 틀렸습니다."),
-        ]
-    )
+    @ApiResponse(responseCode = "200")
+    @ApiErrorResponses([LOGIN_UNAUTHENTICATED])
     fun login(@RequestBody @Valid request: UserLoginRequest): ResponseEntity<UserLoginResponse> {
         val response = authService.login(request.toServiceDto())
         val headers = jwtProvider.createToken(response.userId)
@@ -169,20 +117,8 @@ class AuthController(
 
     @PatchMapping("/api/users/password")
     @Operation(summary = "비밀번호 변경", security = [SecurityRequirement(name = ACCESS_TOKEN_KEY)])
-    @ApiResponses(
-        value = [
-            ApiResponse(responseCode = "200", description = "비밀번호 변경 성공"),
-            ApiResponse(responseCode = "400", description = "비밀번호와 비밀번호 재입력이 동일하지 않습니다."),
-            ApiResponse(
-                responseCode = "401",
-                description = """
-                1. 승인되지 않은 요청입니다. 다시 로그인 해주세요.
-                2. 아이디 또는 비밀번호가 틀렸습니다.
-                """
-            ),
-            ApiResponse(responseCode = "403", description = "권한이 없는 요청입니다. 로그인 후에 다시 시도 해주세요."),
-        ]
-    )
+    @ApiResponse(responseCode = "200")
+    @ApiErrorResponses([PASSWORD_MATCH_INVALID, LOGIN_UNAUTHENTICATED, TOKEN_UNAUTHENTICATED, TOKEN_UNAUTHORIZED])
     fun changePassword(
         principal: Principal,
         @RequestBody @Valid request: UserChangePasswordRequest
@@ -194,13 +130,8 @@ class AuthController(
 
     @PostMapping("/api/users/token")
     @Operation(summary = "토큰 재발급", security = [SecurityRequirement(name = REFRESH_TOKEN_KEY)])
-    @ApiResponses(
-        value = [
-            ApiResponse(responseCode = "200", description = "토큰 재발급 성공"),
-            ApiResponse(responseCode = "401", description = "승인되지 않은 요청입니다. 다시 로그인 해주세요."),
-            ApiResponse(responseCode = "403", description = "권한이 없는 요청입니다. 로그인 후에 다시 시도 해주세요."),
-        ]
-    )
+    @ApiResponse(responseCode = "200")
+    @ApiErrorResponses([TOKEN_UNAUTHENTICATED, TOKEN_UNAUTHORIZED])
     fun refreshToken(principal: Principal): ResponseEntity<StringResponse> {
         val headers = jwtProvider.createToken(UserUtility.getUserId(principal))
 

--- a/src/main/kotlin/com/alloon/alloonserver/common/constant/ExceptionCode.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/common/constant/ExceptionCode.kt
@@ -6,6 +6,7 @@ import org.springframework.http.HttpStatus.*
 enum class ExceptionCode(
     val httpStatus: HttpStatus,
     val message: String,
+    val description: String? = null,
 ) {
 
     /**
@@ -44,7 +45,7 @@ enum class ExceptionCode(
 
     // @Pattern, @Email
     EMAIL_FORMAT_INVALID(BAD_REQUEST, "올바른 이메일 형식을 입력해 주세요."),
-    USERNAME_FORMAT_INVALID(BAD_REQUEST, "아이디는 소문자 영어, 숫자, 특수문자(_)의 조합으로 입력해 주세요."),
+    USERNAME_FORMAT_INVALID(BAD_REQUEST, "아이디는 소문자 영어, 숫자, 특수문자(_)의 조합으로 입력해 주세요.", "아이디는 5~20자만 가능하고, 정규식은 ^[a-z0-9_]+$ 입니다."),
     PASSWORD_FORMAT_INVALID(BAD_REQUEST, "비밀번호는 영어, 숫자, 특수문자(#$@!%&*)의 조합으로 입력해 주세요."),
     NEW_PASSWORD_FORMAT_INVALID(BAD_REQUEST, "비밀번호는 영어, 숫자, 특수문자(#$@!%&*)의 조합으로 입력해 주세요."),
     REPORT_TYPE_INVALID(BAD_REQUEST, "신고 타입은 'CHALLENGE', 'CHALLENGE_MEMBER', 'FEED' 중 하나여야 됩니다."),
@@ -103,7 +104,10 @@ enum class ExceptionCode(
     /**
      * 415 Unsupported Media Type
      */
-    IMAGE_TYPE_UNSUPPORTED(UNSUPPORTED_MEDIA_TYPE, "이미지는 '.jpeg', '.jpg', '.png', '.gif' 타입만 가능합니다."),
+    IMAGE_TYPE_UNSUPPORTED(
+        UNSUPPORTED_MEDIA_TYPE,
+        "이미지는 '.jpeg', '.jpg', '.png', '.gif' 타입만 가능합니다."
+    ),
 
     /**
      * 500 Internal Server Error

--- a/src/main/kotlin/com/alloon/alloonserver/common/exception/CustomExceptionHandler.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/common/exception/CustomExceptionHandler.kt
@@ -1,6 +1,7 @@
 package com.alloon.alloonserver.common.exception
 
-import com.alloon.alloonserver.common.constant.ExceptionCode.*
+import com.alloon.alloonserver.common.constant.ExceptionCode.FILE_SIZE_EXCEED
+import com.alloon.alloonserver.common.constant.ExceptionCode.SERVER_ERROR
 import com.alloon.alloonserver.common.response.CustomException
 import com.alloon.alloonserver.common.response.ErrorResponse
 import io.sentry.Sentry
@@ -14,7 +15,6 @@ import org.springframework.http.converter.HttpMessageNotReadableException
 import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
-import org.springframework.web.context.request.ServletWebRequest
 import org.springframework.web.context.request.WebRequest
 import org.springframework.web.multipart.MaxUploadSizeExceededException
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler
@@ -27,8 +27,7 @@ class CustomExceptionHandler : ResponseEntityExceptionHandler() {
         ex: CustomException,
         request: HttpServletRequest
     ): ResponseEntity<ErrorResponse> {
-        val path = request.requestURL.toString()
-        val response = ErrorResponse.of(ex.exceptionCode, path)
+        val response = ErrorResponse.of(ex.exceptionCode)
         return ResponseEntity.status(ex.exceptionCode.httpStatus).body(response)
     }
 
@@ -38,8 +37,7 @@ class CustomExceptionHandler : ResponseEntityExceptionHandler() {
         request: HttpServletRequest
     ): ResponseEntity<ErrorResponse> {
         logger.info("Exception : ${ex.message}")
-        val path = request.requestURL.toString()
-        val response = ErrorResponse.of(SERVER_ERROR, path)
+        val response = ErrorResponse.of(SERVER_ERROR)
         return ResponseEntity.status(INTERNAL_SERVER_ERROR).body(response)
     }
 
@@ -55,10 +53,7 @@ class CustomExceptionHandler : ResponseEntityExceptionHandler() {
         val message = ex.bindingResult.fieldErrors.map {
             mapOf(it.field to it.defaultMessage)
         }
-        val httpServletRequest = (request as ServletWebRequest).request
-        val path = httpServletRequest.requestURL.toString()
-
-        val response = ErrorResponse(status.value(), status.toString().split(" ")[1], message, path)
+        val response = ErrorResponse(status.toString().split(" ")[1], message)
 
         return ResponseEntity.status(BAD_REQUEST).body(response)
     }
@@ -74,9 +69,7 @@ class CustomExceptionHandler : ResponseEntityExceptionHandler() {
             val property = propertyPaths.lastOrNull()
             message.add(mapOf(property to it.message))
         }
-        val path = request.requestURL.toString()
-
-        val response = ErrorResponse(BAD_REQUEST.value(), BAD_REQUEST.name, message, path)
+        val response = ErrorResponse(BAD_REQUEST.name, message)
 
         return ResponseEntity.status(BAD_REQUEST).body(response)
     }
@@ -88,10 +81,7 @@ class CustomExceptionHandler : ResponseEntityExceptionHandler() {
         request: WebRequest
     ): ResponseEntity<Any>? {
         val message = ex.mostSpecificCause.message.toString()
-        val httpServletRequest = (request as ServletWebRequest).request
-        val path = httpServletRequest.requestURL.toString()
-
-        val response = ErrorResponse(status.value(), status.toString().split(" ")[1], message, path)
+        val response = ErrorResponse(status.toString().split(" ")[1], message)
 
         return ResponseEntity.status(BAD_REQUEST).body(response)
     }
@@ -105,9 +95,7 @@ class CustomExceptionHandler : ResponseEntityExceptionHandler() {
         status: HttpStatusCode,
         request: WebRequest
     ): ResponseEntity<Any>? {
-        val httpServletRequest = (request as ServletWebRequest).request
-        val path = httpServletRequest.requestURL.toString()
-        val response = ErrorResponse.of(FILE_SIZE_EXCEED, path)
+        val response = ErrorResponse.of(FILE_SIZE_EXCEED)
         return ResponseEntity.status(PAYLOAD_TOO_LARGE).body(response)
     }
 
@@ -115,10 +103,12 @@ class CustomExceptionHandler : ResponseEntityExceptionHandler() {
      * 500 Internal Server Error
      */
     @ExceptionHandler(Exception::class)
-    protected fun handleException(ex: Exception, request: HttpServletRequest): ResponseEntity<ErrorResponse> {
+    protected fun handleException(
+        ex: Exception,
+        request: HttpServletRequest
+    ): ResponseEntity<ErrorResponse> {
         Sentry.captureException(ex)
-        val path = request.requestURL.toString()
-        val response = ErrorResponse.of(SERVER_ERROR, path)
+        val response = ErrorResponse.of(SERVER_ERROR)
         return ResponseEntity.status(INTERNAL_SERVER_ERROR).body(response)
     }
 }

--- a/src/main/kotlin/com/alloon/alloonserver/common/response/ApiErrorResponses.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/common/response/ApiErrorResponses.kt
@@ -1,0 +1,9 @@
+package com.alloon.alloonserver.common.response
+
+import com.alloon.alloonserver.common.constant.ExceptionCode
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+@ApiResponses(value = [])
+annotation class ApiErrorResponses(val exceptionCodes: Array<ExceptionCode>)

--- a/src/main/kotlin/com/alloon/alloonserver/common/response/ErrorResponse.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/common/response/ErrorResponse.kt
@@ -1,20 +1,16 @@
 package com.alloon.alloonserver.common.response
 
 import com.alloon.alloonserver.common.constant.ExceptionCode
-import java.time.LocalDateTime
 
 data class ErrorResponse(
-    val status: Int,
     val code: String,
     val message: Any,
-    val path: String,
-    val timestamp: LocalDateTime = LocalDateTime.now(),
 ) {
 
     companion object {
 
-        fun of(exceptionCode: ExceptionCode, path: String): ErrorResponse {
-            return ErrorResponse(exceptionCode.httpStatus.value(), exceptionCode.name, exceptionCode.message, path)
+        fun of(exceptionCode: ExceptionCode): ErrorResponse {
+            return ErrorResponse(exceptionCode.name, exceptionCode.message)
         }
     }
 }

--- a/src/main/kotlin/com/alloon/alloonserver/common/response/StringResponse.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/common/response/StringResponse.kt
@@ -1,0 +1,5 @@
+package com.alloon.alloonserver.common.response
+
+data class StringResponse(
+    val successMessage: String,
+)

--- a/src/main/kotlin/com/alloon/alloonserver/common/response/StringResponse.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/common/response/StringResponse.kt
@@ -1,5 +1,0 @@
-package com.alloon.alloonserver.common.response
-
-data class StringResponse(
-    val successMessage: String,
-)

--- a/src/main/kotlin/com/alloon/alloonserver/common/response/SuccessResponse.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/common/response/SuccessResponse.kt
@@ -1,0 +1,7 @@
+package com.alloon.alloonserver.common.response
+
+data class SuccessResponse<T>(
+    val code: Int,
+    val message: String,
+    val data: T,
+)

--- a/src/main/kotlin/com/alloon/alloonserver/common/response/SuccessResponse.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/common/response/SuccessResponse.kt
@@ -5,3 +5,11 @@ data class SuccessResponse<T>(
     val message: String,
     val data: T,
 )
+
+data class StringSuccessResponse(
+    val successMessage: String,
+)
+
+data class CollectionSuccessResponse(
+    val list: List<String>,
+)

--- a/src/main/kotlin/com/alloon/alloonserver/common/response/SuccessResponseBodyAdvice.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/common/response/SuccessResponseBodyAdvice.kt
@@ -1,0 +1,42 @@
+package com.alloon.alloonserver.common.response
+
+import org.springframework.core.MethodParameter
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.http.converter.HttpMessageConverter
+import org.springframework.http.server.ServerHttpRequest
+import org.springframework.http.server.ServerHttpResponse
+import org.springframework.http.server.ServletServerHttpResponse
+import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice
+
+@RestControllerAdvice(basePackages = ["com.alloon.alloonserver.api.controller"])
+class SuccessResponseBodyAdvice : ResponseBodyAdvice<Any> {
+
+    override fun supports(
+        returnType: MethodParameter,
+        converterType: Class<out HttpMessageConverter<*>>
+    ): Boolean {
+        return true
+    }
+
+    override fun beforeBodyWrite(
+        body: Any?,
+        returnType: MethodParameter,
+        selectedContentType: MediaType,
+        selectedConverterType: Class<out HttpMessageConverter<*>>,
+        request: ServerHttpRequest,
+        response: ServerHttpResponse
+    ): Any? {
+        val servletResponse = (response as ServletServerHttpResponse).servletResponse
+
+        val status = servletResponse.status
+        val resolve = HttpStatus.resolve(status) ?: return body
+
+        if (resolve.is2xxSuccessful) {
+            return SuccessResponse(status, "성공", body)
+        }
+
+        return body
+    }
+}

--- a/src/main/kotlin/com/alloon/alloonserver/config/SwaggerConfig.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/config/SwaggerConfig.kt
@@ -1,17 +1,23 @@
 package com.alloon.alloonserver.config
 
 import com.alloon.alloonserver.common.constant.CustomHttpHeaders
+import com.alloon.alloonserver.common.response.ApiErrorResponses
 import io.swagger.v3.oas.annotations.OpenAPIDefinition
 import io.swagger.v3.oas.annotations.info.Info
 import io.swagger.v3.oas.models.Components
 import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.oas.models.Operation
+import io.swagger.v3.oas.models.examples.Example
+import io.swagger.v3.oas.models.media.Content
+import io.swagger.v3.oas.models.media.MediaType
 import io.swagger.v3.oas.models.media.Schema
+import io.swagger.v3.oas.models.responses.ApiResponse
 import io.swagger.v3.oas.models.security.SecurityScheme
 import org.springdoc.core.customizers.OperationCustomizer
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.http.HttpHeaders
+import org.springframework.web.method.HandlerMethod
 
 @OpenAPIDefinition(
     info = Info(
@@ -47,8 +53,9 @@ class SwaggerConfig {
 
     @Bean
     fun operationCustomizer(): OperationCustomizer {
-        return OperationCustomizer { operation, _ ->
+        return OperationCustomizer { operation, handlerMethod ->
             addResponseBodySchemaExample(operation)
+            addApiErrorResponses(operation, handlerMethod)
             operation
         }
     }
@@ -66,6 +73,30 @@ class SwaggerConfig {
                 }
                 mediaType.schema = schema
             }
+        }
+    }
+
+    private fun addApiErrorResponses(operation: Operation, handlerMethod: HandlerMethod) {
+        val apiErrorResponses = handlerMethod.method.getAnnotation(ApiErrorResponses::class.java)
+
+        apiErrorResponses?.exceptionCodes?.forEach { exceptionCode ->
+            val example = Example().apply {
+                summary = exceptionCode.name
+                value = mapOf("code" to exceptionCode.name, "message" to exceptionCode.message)
+                description = exceptionCode.description
+            }
+            val apiResponse = operation.responses[exceptionCode.httpStatus.value().toString()]
+            val mediaType = apiResponse?.content?.get("application/json") ?: MediaType()
+            val examples = mediaType.examples?.toMutableMap() ?: mutableMapOf()
+
+            examples[exceptionCode.name] = example
+
+            operation.responses.addApiResponse(
+                exceptionCode.httpStatus.value().toString(),
+                ApiResponse().content(
+                    Content().addMediaType("application/json", MediaType().examples(examples))
+                )
+            )
         }
     }
 

--- a/src/main/kotlin/com/alloon/alloonserver/config/SwaggerConfig.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/config/SwaggerConfig.kt
@@ -5,7 +5,10 @@ import io.swagger.v3.oas.annotations.OpenAPIDefinition
 import io.swagger.v3.oas.annotations.info.Info
 import io.swagger.v3.oas.models.Components
 import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.Operation
+import io.swagger.v3.oas.models.media.Schema
 import io.swagger.v3.oas.models.security.SecurityScheme
+import org.springdoc.core.customizers.OperationCustomizer
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.http.HttpHeaders
@@ -40,6 +43,30 @@ class SwaggerConfig {
             .addSecuritySchemes(REFRESH_TOKEN_KEY, refreshTokenSecurityScheme)
 
         return OpenAPI().components(components)
+    }
+
+    @Bean
+    fun operationCustomizer(): OperationCustomizer {
+        return OperationCustomizer { operation, _ ->
+            addResponseBodySchemaExample(operation)
+            operation
+        }
+    }
+
+    private fun addResponseBodySchemaExample(operation: Operation) {
+        val filterKeys = operation.responses.filterKeys { it.startsWith("2") }
+
+        filterKeys.forEach { (code, response) ->
+            response.content.forEach { (_, mediaType) ->
+                val data = mediaType.schema
+                val schema = Schema<String>().apply {
+                    addProperty("code", Schema<String>().example(code))
+                    addProperty("message", Schema<String>().example("성공"))
+                    addProperty("data", data)
+                }
+                mediaType.schema = schema
+            }
+        }
     }
 
     companion object {

--- a/src/main/kotlin/com/alloon/alloonserver/config/auth/CustomAuthenticationEntryPoint.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/config/auth/CustomAuthenticationEntryPoint.kt
@@ -22,8 +22,7 @@ class CustomAuthenticationEntryPoint(
         response: HttpServletResponse?,
         authException: AuthenticationException?
     ) {
-        val path = request?.requestURL.toString()
-        val errorResponse = ErrorResponse.of(TOKEN_UNAUTHENTICATED, path)
+        val errorResponse = ErrorResponse.of(TOKEN_UNAUTHENTICATED)
 
         response?.apply {
             status = UNAUTHORIZED.value()

--- a/src/test/kotlin/com/alloon/alloonserver/api/controller/challenge/ChallengeControllerTest.kt
+++ b/src/test/kotlin/com/alloon/alloonserver/api/controller/challenge/ChallengeControllerTest.kt
@@ -60,7 +60,6 @@ class ChallengeControllerTest : RestDocsSupport() {
 
         // then
         resultActions.andExpect(status().isCreated)
-            .andExpect(jsonPath("$.message").value("챌린지 생성이 완료되었습니다."))
     }
 
     @DisplayName("챌린지 예시 이미지 전체 조회를 하면 200을 반환한다")
@@ -97,7 +96,6 @@ class ChallengeControllerTest : RestDocsSupport() {
 
         // then
         resultActions.andExpect(status().isOk)
-            .andExpect(jsonPath("$.message").value("지금 인기있는 챌린지를 전체 조회했습니다."))
     }
 
     @DisplayName("챌린지가 없는 경우 지금 인기있는 챌린지 조회를 하면 200을 반환한다")
@@ -115,7 +113,6 @@ class ChallengeControllerTest : RestDocsSupport() {
 
         // then
         resultActions.andExpect(status().isOk)
-            .andExpect(jsonPath("$.message").value("지금 인기있는 챌린지가 없습니다."))
     }
 
     @DisplayName("챌린지 멤버가 챌린지 소개 조회를 성공하면 200을 반환한다")
@@ -134,7 +131,6 @@ class ChallengeControllerTest : RestDocsSupport() {
 
         // then
         resultActions.andExpect(status().isOk)
-            .andExpect(jsonPath("$.message").value("챌린지 소개를 조회했습니다."))
     }
 
     @DisplayName("챌린지 멤버가 개인목표 작성을 성공하면 200을 반환한다")
@@ -156,7 +152,7 @@ class ChallengeControllerTest : RestDocsSupport() {
 
         // then
         resultActions.andExpect(status().isOk)
-            .andExpect(jsonPath("$.message").value("챌린지 개인목표 작성이 완료되었습니다."))
+            .andExpect(jsonPath("$.successMessage").value("챌린지 개인목표 작성이 완료되었습니다."))
     }
 
     @DisplayName("챌린지 멤버가 챌린지 파티원 조회를 성공하면 200을 반환한다")
@@ -176,7 +172,6 @@ class ChallengeControllerTest : RestDocsSupport() {
 
         // then
         resultActions.andExpect(status().isOk)
-            .andExpect(jsonPath("$.message").value("챌린지 파티원을 전체 조회했습니다."))
     }
 
     private fun getCreateChallengeRequest(): CreateChallengeRequest {

--- a/src/test/kotlin/com/alloon/alloonserver/api/controller/user/AuthControllerTest.kt
+++ b/src/test/kotlin/com/alloon/alloonserver/api/controller/user/AuthControllerTest.kt
@@ -49,16 +49,18 @@ class AuthControllerTest : RestDocsSupport() {
 
         // then
         resultActions.andExpect(status().isCreated)
-            .andExpect(jsonPath("$.message").value("이메일 인증코드를 보냈습니다."))
+            .andExpect(jsonPath("$.successMessage").value("이메일 인증코드를 보냈습니다."))
     }
 
     @DisplayName("회원 가입을 하면 201을 반환한다")
     @Test
     fun givenValid_whenRegister_thenReturn201() {
         // given
-        val request = UserRegisterRequest("tester@photi.com", "000000", "tester", "password1!", "password1!")
+        val request =
+            UserRegisterRequest("tester@photi.com", "000000", "tester", "password1!", "password1!")
+        val response = UserRegisterResponse(1L, request.username)
 
-        every { authService.registerUser(any()) } returns UserRegisterResponse(1L, request.username)
+        every { authService.registerUser(any()) } returns response
         every { jwtProvider.createToken(any()) } returns HttpHeaders().apply {
             set(AUTHORIZATION, "access-token")
             set(REFRESH_TOKEN, "refresh-token")
@@ -73,7 +75,8 @@ class AuthControllerTest : RestDocsSupport() {
 
         // then
         resultActions.andExpect(status().isCreated)
-            .andExpect(jsonPath("$.message").value("회원 가입을 완료했습니다."))
+            .andExpect(jsonPath("$.userId").value(response.userId))
+            .andExpect(jsonPath("$.username").value(response.username))
     }
 
     @DisplayName("아이디 찾기를 하면 200을 반환한다")
@@ -93,7 +96,7 @@ class AuthControllerTest : RestDocsSupport() {
 
         // then
         resultActions.andExpect(status().isOk)
-            .andExpect(jsonPath("$.message").value("아이디를 이메일로 전송했습니다."))
+            .andExpect(jsonPath("$.successMessage").value("아이디를 이메일로 전송했습니다."))
     }
 
     @DisplayName("비밀번호 찾기를 하면 200을 반환한다")
@@ -113,7 +116,7 @@ class AuthControllerTest : RestDocsSupport() {
 
         // then
         resultActions.andExpect(status().isOk)
-            .andExpect(jsonPath("$.message").value("임시 비밀번호를 이메일로 전송했습니다."))
+            .andExpect(jsonPath("$.successMessage").value("임시 비밀번호를 이메일로 전송했습니다."))
     }
 
     @DisplayName("회원 로그인을 하면 200을 반환한다")
@@ -121,8 +124,9 @@ class AuthControllerTest : RestDocsSupport() {
     fun givenValid_whenLogin_thenReturn200() {
         // given
         val request = UserLoginRequest("tester", "password1!")
+        val response = UserLoginResponse(1, request.username, "", false)
 
-        every { authService.login(request.toServiceDto()) } returns UserLoginResponse(1, request.username, "", false)
+        every { authService.login(request.toServiceDto()) } returns response
         every { jwtProvider.createToken(any()) } returns HttpHeaders().apply {
             set(AUTHORIZATION, "access-token")
             set(REFRESH_TOKEN, "refresh-token")
@@ -137,7 +141,10 @@ class AuthControllerTest : RestDocsSupport() {
 
         // then
         resultActions.andExpect(status().isOk)
-            .andExpect(jsonPath("$.message").value("로그인을 했습니다."))
+            .andExpect(jsonPath("$.userId").value(response.userId))
+            .andExpect(jsonPath("$.username").value(response.username))
+            .andExpect(jsonPath("$.imageUrl").value(response.imageUrl))
+            .andExpect(jsonPath("$.temporaryPasswordYn").value(response.temporaryPasswordYn))
     }
 
     @DisplayName("비밀번호 변경을 하면 200을 반환한다")
@@ -159,7 +166,7 @@ class AuthControllerTest : RestDocsSupport() {
 
         // then
         resultActions.andExpect(status().isOk)
-            .andExpect(jsonPath("$.message").value("비밀번호가 변경되었습니다."))
+            .andExpect(jsonPath("$.successMessage").value("비밀번호가 변경되었습니다."))
     }
 
     @DisplayName("토큰을 재발급하면 200을 반환한다")
@@ -180,7 +187,7 @@ class AuthControllerTest : RestDocsSupport() {
 
         // then
         resultActions.andExpect(status().isOk)
-            .andExpect(jsonPath("$.message").value("토큰이 재발급 됐습니다."))
+            .andExpect(jsonPath("$.successMessage").value("토큰이 재발급 됐습니다."))
     }
 
     @DisplayName("이메일 인증코드 검증을 하면 200을 반환한다")
@@ -200,7 +207,7 @@ class AuthControllerTest : RestDocsSupport() {
 
         // then
         resultActions.andExpect(status().isOk)
-            .andExpect(jsonPath("$.message").value("이메일 인증코드가 확인 되었습니다."))
+            .andExpect(jsonPath("$.successMessage").value("이메일 인증코드가 확인 되었습니다."))
     }
 
     @DisplayName("이메일 미입력시 이메일 인증코드 검증을 하면 400을 반환한다")
@@ -260,7 +267,8 @@ class AuthControllerTest : RestDocsSupport() {
     @Test
     fun givenBlankVerificationCode_whenRegister_thenReturn400() {
         // given
-        val request = UserRegisterRequest("tester@photi.com", "", "tester", "password1!", "password1!")
+        val request =
+            UserRegisterRequest("tester@photi.com", "", "tester", "password1!", "password1!")
 
         every { authService.registerUser(any()) } returns UserRegisterResponse(1, request.username)
 
@@ -279,7 +287,8 @@ class AuthControllerTest : RestDocsSupport() {
     @Test
     fun givenBlankUsername_whenRegister_thenReturn400() {
         // given
-        val request = UserRegisterRequest("tester@photi.com", "000000", "", "password1!", "password1!")
+        val request =
+            UserRegisterRequest("tester@photi.com", "000000", "", "password1!", "password1!")
 
         every { authService.registerUser(any()) } returns UserRegisterResponse(1, request.username)
 


### PR DESCRIPTION
## 📋 이슈 번호
- close #78 
  </br>

## 🛠 구현 사항
- `@ApiErrorResponses` 어노테이션 생성
- 인증, 챌린지 API controller 수정 (ResponseEntity가 반환되도록 변경, 어노테이션 적용)
- swagger 성공, 에러 응답 예시 커스텀
  </br>

## 📚 기타
- 
  </br>