### PR TITLE
[feat] 최신순 - 모든 챌린지 조회 API

### DIFF
--- a/src/main/kotlin/com/alloon/alloonserver/api/controller/challenge/ChallengeController.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/api/controller/challenge/ChallengeController.kt
@@ -9,6 +9,7 @@ import com.alloon.alloonserver.api.controller.challenge.response.FindPopularChal
 import com.alloon.alloonserver.common.constant.ExceptionCode.*
 import com.alloon.alloonserver.common.response.ApiErrorResponses
 import com.alloon.alloonserver.common.response.CollectionSuccessResponse
+import com.alloon.alloonserver.common.response.SliceResponse
 import com.alloon.alloonserver.common.response.StringSuccessResponse
 import com.alloon.alloonserver.common.util.UserUtility
 import com.alloon.alloonserver.config.SwaggerConfig.Companion.ACCESS_TOKEN_KEY
@@ -19,6 +20,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
+import org.springframework.data.domain.PageRequest
 import org.springframework.http.HttpStatus.CREATED
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
@@ -29,12 +31,13 @@ import java.security.Principal
 
 @Validated
 @RestController
+@RequestMapping("/api/challenges")
 @Tag(name = "Challenge", description = "챌린지 API")
 class ChallengeController(
     private val challengeService: ChallengeService
 ) {
 
-    @PostMapping("/api/challenges", consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
+    @PostMapping(consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
     @Operation(summary = "챌린지 생성", security = [SecurityRequirement(name = ACCESS_TOKEN_KEY)])
     @ApiResponse(responseCode = "201")
     @ApiErrorResponses([EMPTY_FILE_INVALID, TOKEN_UNAUTHENTICATED, TOKEN_UNAUTHORIZED, USER_NOT_FOUND, IMAGE_TYPE_UNSUPPORTED])
@@ -53,7 +56,7 @@ class ChallengeController(
         return ResponseEntity.status(CREATED).body(response)
     }
 
-    @GetMapping("/api/challenges/example-images")
+    @GetMapping("/example-images")
     @Operation(summary = "챌린지 예시 이미지 리스트 조회")
     @ApiResponse(responseCode = "200")
     fun getChallengeExampleImages(): ResponseEntity<CollectionSuccessResponse> {
@@ -62,7 +65,7 @@ class ChallengeController(
         return ResponseEntity.ok(CollectionSuccessResponse(response))
     }
 
-    @GetMapping("/api/challenges/popular")
+    @GetMapping("/popular")
     @Operation(
         summary = "지금 인기있는 챌린지 조회",
         description = "공개, 비공개 및 종료되지 않은 챌린지가 방문순으로 최대 5개 조회됩니다."
@@ -74,7 +77,7 @@ class ChallengeController(
         return ResponseEntity.ok(response)
     }
 
-    @GetMapping("/api/challenges/{challengeId}/info")
+    @GetMapping("/{challengeId}/info")
     @Operation(summary = "챌린지 소개 조회", security = [SecurityRequirement(name = ACCESS_TOKEN_KEY)])
     @ApiResponse(responseCode = "200")
     @ApiErrorResponses([TOKEN_UNAUTHENTICATED, TOKEN_UNAUTHORIZED, CHALLENGE_NOT_FOUND])
@@ -88,7 +91,7 @@ class ChallengeController(
         return ResponseEntity.ok(response)
     }
 
-    @PatchMapping("/api/challenges/{challengeId}/challenge-members/goal")
+    @PatchMapping("/{challengeId}/challenge-members/goal")
     @Operation(summary = "챌린지 개인목표 작성", security = [SecurityRequirement(name = ACCESS_TOKEN_KEY)])
     @ApiResponse(responseCode = "200")
     @ApiErrorResponses([TOKEN_UNAUTHENTICATED, TOKEN_UNAUTHORIZED, CHALLENGE_MEMBER_NOT_FOUND])
@@ -106,7 +109,7 @@ class ChallengeController(
         return ResponseEntity.ok(StringSuccessResponse("챌린지 개인목표 작성이 완료되었습니다."))
     }
 
-    @GetMapping("/api/challenges/{challengeId}/challenge-members")
+    @GetMapping("/{challengeId}/challenge-members")
     @Operation(
         summary = "챌린지 파티원 조회",
         description = "파티장 -> 본인 -> 가입순으로 파티원이 전체 조회됩니다.",
@@ -121,6 +124,19 @@ class ChallengeController(
         val challengeMembers =
             challengeService.findChallengeMembers(UserUtility.getUserId(principal), challengeId)
         val response = FindChallengeMembersResponse.of(challengeMembers)
+
+        return ResponseEntity.ok(response)
+    }
+
+    @GetMapping
+    @Operation(summary = "모든 챌린지 조회", description = "종료 날짜 최신순으로 모든 챌린지가 조회됩니다.")
+    @ApiResponse(responseCode = "200")
+    fun findAllChallenges(
+        @Parameter(description = "페이지 시작 번호") @RequestParam(defaultValue = "0") page: Int,
+        @Parameter(description = "한 페이지당 content 최대 갯수") @RequestParam(defaultValue = "10") size: Int,
+    ): ResponseEntity<SliceResponse<FindPopularChallengesResponse>> {
+        val challenges = challengeService.findAllChallenges(PageRequest.of(page, size))
+        val response = SliceResponse.of(challenges)
 
         return ResponseEntity.ok(response)
     }

--- a/src/main/kotlin/com/alloon/alloonserver/common/response/SliceResponse.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/common/response/SliceResponse.kt
@@ -1,0 +1,25 @@
+package com.alloon.alloonserver.common.response
+
+import org.springframework.data.domain.Slice
+
+data class SliceResponse<T>(
+    val content: List<T>,
+    val page: Int,
+    val size: Int,
+    val first: Boolean,
+    val last: Boolean,
+) {
+
+    companion object {
+
+        fun <T> of(sliceContent: Slice<T>): SliceResponse<T> {
+            return SliceResponse(
+                sliceContent.content,
+                sliceContent.number,
+                sliceContent.size,
+                sliceContent.isFirst,
+                sliceContent.isLast,
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/alloon/alloonserver/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/config/SecurityConfig.kt
@@ -4,6 +4,7 @@ import com.alloon.alloonserver.config.auth.CustomAuthenticationEntryPoint
 import com.alloon.alloonserver.config.auth.CustomAuthenticationFilter
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.http.HttpMethod.POST
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.config.http.SessionCreationPolicy
@@ -27,17 +28,20 @@ class SecurityConfig(
             .csrf { it.disable() }
             .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
             .authorizeHttpRequests {
+                it.requestMatchers(POST, "/api/challenges").authenticated()
                 it.requestMatchers(
                     "/api/users/token",
                     "/api/users/password",
-                    "/api/challenges",
                     "/api/challenges/{challengeId}/info",
                     "/api/challenges/{challengeId}/challenge-members/goal",
                     "/api/challenges/{challengeId}/challenge-members",
                 ).authenticated()
                 it.anyRequest().permitAll()
             }
-            .addFilterBefore(customAuthenticationFilter, UsernamePasswordAuthenticationFilter::class.java)
+            .addFilterBefore(
+                customAuthenticationFilter,
+                UsernamePasswordAuthenticationFilter::class.java
+            )
             .exceptionHandling { it.authenticationEntryPoint(customAuthenticationEntryPoint) }
             .build()
     }

--- a/src/main/kotlin/com/alloon/alloonserver/domain/challenge/custom/ChallengeCustomRepository.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/domain/challenge/custom/ChallengeCustomRepository.kt
@@ -2,6 +2,8 @@ package com.alloon.alloonserver.domain.challenge.custom
 
 import com.alloon.alloonserver.domain.challenge.Challenge
 import com.alloon.alloonserver.service.challenge.dto.FindPopularChallengesDto
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
 
 interface ChallengeCustomRepository {
 
@@ -10,4 +12,6 @@ interface ChallengeCustomRepository {
     fun findPopular(): List<FindPopularChallengesDto>
 
     fun findInfoById(id: Long): Challenge?
+
+    fun findAllOrderByEndDate(pageable: Pageable): Slice<FindPopularChallengesDto>
 }

--- a/src/main/kotlin/com/alloon/alloonserver/domain/challenge/custom/ChallengeCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/domain/challenge/custom/ChallengeCustomRepositoryImpl.kt
@@ -8,6 +8,9 @@ import com.alloon.alloonserver.service.challenge.dto.FindPopularChallengesDto
 import com.alloon.alloonserver.service.challenge.dto.QFindPopularChallengesDto
 import com.querydsl.core.types.dsl.BooleanExpression
 import com.querydsl.jpa.impl.JPAQueryFactory
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
+import org.springframework.data.domain.SliceImpl
 import org.springframework.stereotype.Repository
 
 @Repository
@@ -48,6 +51,35 @@ class ChallengeCustomRepositoryImpl(
             .join(challenge.rules).fetchJoin()
             .where(challenge.id.eq(id))
             .fetchFirst()
+    }
+
+    override fun findAllOrderByEndDate(pageable: Pageable): Slice<FindPopularChallengesDto> {
+        val pageSize = pageable.pageSize
+        val content = queryFactory
+            .select(
+                QFindPopularChallengesDto(
+                    challenge.id,
+                    challenge.name,
+                    challenge.endDate,
+                    challenge.imageUrl,
+                    challenge.hashtags
+                )
+            )
+            .from(challenge)
+            .where(eqServiceStatus(ACTIVE))
+            .orderBy(challenge.endDate.asc())
+            .offset(pageable.offset)
+            .limit(pageSize + 1L)
+            .fetch()
+
+        val hasNext = if (content.size > pageSize) {
+            content.removeAt(pageSize)
+            true
+        } else {
+            false
+        }
+
+        return SliceImpl(content, pageable, hasNext)
     }
 
     private fun eqServiceStatus(serviceStatus: ServiceStatus?): BooleanExpression? =

--- a/src/main/kotlin/com/alloon/alloonserver/service/challenge/ChallengeService.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/service/challenge/ChallengeService.kt
@@ -1,5 +1,6 @@
 package com.alloon.alloonserver.service.challenge
 
+import com.alloon.alloonserver.api.controller.challenge.response.FindPopularChallengesResponse
 import com.alloon.alloonserver.common.constant.ExceptionCode.*
 import com.alloon.alloonserver.common.response.CustomException
 import com.alloon.alloonserver.domain.challenge.*
@@ -7,6 +8,8 @@ import com.alloon.alloonserver.domain.user.UserRepository
 import com.alloon.alloonserver.service.challenge.dto.*
 import com.alloon.alloonserver.service.s3.FolderType.CHALLENGES
 import com.alloon.alloonserver.service.s3.S3Service
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.multipart.MultipartFile
@@ -69,5 +72,10 @@ class ChallengeService(
 
     fun findChallengeMembers(userId: Long, challengeId: Long): List<FindChallengeMembersDto> {
         return challengeMemberRepository.findAllByChallengeId(userId, challengeId)
+    }
+
+    fun findAllChallenges(pageable: Pageable): Slice<FindPopularChallengesResponse> {
+        return challengeRepository.findAllOrderByEndDate(pageable)
+            .map { FindPopularChallengesResponse.of(it) }
     }
 }

--- a/src/test/kotlin/com/alloon/alloonserver/api/controller/challenge/ChallengeControllerTest.kt
+++ b/src/test/kotlin/com/alloon/alloonserver/api/controller/challenge/ChallengeControllerTest.kt
@@ -5,6 +5,7 @@ import com.alloon.alloonserver.api.controller.challenge.request.CreateChallengeH
 import com.alloon.alloonserver.api.controller.challenge.request.CreateChallengeRequest
 import com.alloon.alloonserver.api.controller.challenge.request.CreateChallengeRuleRequest
 import com.alloon.alloonserver.api.controller.challenge.request.UpdateChallengeMemberGoalRequest
+import com.alloon.alloonserver.api.controller.challenge.response.FindPopularChallengesResponse
 import com.alloon.alloonserver.service.challenge.ChallengeService
 import com.alloon.alloonserver.service.challenge.dto.*
 import io.mockk.every
@@ -13,6 +14,8 @@ import io.mockk.mockk
 import io.mockk.runs
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.SliceImpl
 import org.springframework.http.HttpHeaders.AUTHORIZATION
 import org.springframework.http.MediaType.*
 import org.springframework.mock.web.MockMultipartFile
@@ -79,15 +82,9 @@ class ChallengeControllerTest : RestDocsSupport() {
     @Test
     fun givenChallenge_whenFindPopularChallenges_thenReturn200() {
         // given
-        val challenge = FindPopularChallengesDto(
-            1L,
-            "챌린지 이름",
-            LocalDate.of(2024, 12, 1),
-            "https://url.kr/5MhHhD",
-            listOf("해시태그 1", "해시태그 2")
-        )
+        val dto = getFindChallengesDto()
 
-        every { challengeService.findPopularChallenges() } returns listOf(challenge)
+        every { challengeService.findPopularChallenges() } returns listOf(dto)
 
         // when
         val resultActions = mockMvc.perform(
@@ -174,6 +171,28 @@ class ChallengeControllerTest : RestDocsSupport() {
         resultActions.andExpect(status().isOk)
     }
 
+    @DisplayName("모든 챌린지 조회를 성공하면 200을 반환한다")
+    @Test
+    fun givenValid_whenFindAllChallenges_thenReturn200() {
+        // given
+        val dto = getFindChallengesDto()
+        val content = listOf(FindPopularChallengesResponse.of(dto))
+        val pageable = PageRequest.of(0, 10)
+        val hasNext = true
+
+        every { challengeService.findAllChallenges(any()) } returns SliceImpl(
+            content,
+            pageable,
+            hasNext
+        )
+
+        // when
+        val resultActions = mockMvc.perform(get("/api/challenges"))
+
+        // then
+        resultActions.andExpect(status().isOk)
+    }
+
     private fun getCreateChallengeRequest(): CreateChallengeRequest {
         return CreateChallengeRequest(
             "챌린지 이름",
@@ -204,6 +223,16 @@ class ChallengeControllerTest : RestDocsSupport() {
             "챌린지 목표입니다.",
             LocalDate.now(),
             LocalDate.of(2024, 12, 1),
+        )
+    }
+
+    private fun getFindChallengesDto(): FindPopularChallengesDto {
+        return FindPopularChallengesDto(
+            1L,
+            "챌린지 이름",
+            LocalDate.of(2024, 12, 1),
+            "https://url.kr/5MhHhD",
+            listOf("해시태그 1", "해시태그 2")
         )
     }
 }

--- a/src/test/kotlin/com/alloon/alloonserver/service/challenge/ChallengeServiceTest.kt
+++ b/src/test/kotlin/com/alloon/alloonserver/service/challenge/ChallengeServiceTest.kt
@@ -2,7 +2,9 @@ package com.alloon.alloonserver.service.challenge
 
 import com.alloon.alloonserver.common.constant.ExceptionCode.*
 import com.alloon.alloonserver.common.response.CustomException
-import com.alloon.alloonserver.domain.challenge.*
+import com.alloon.alloonserver.domain.challenge.ChallengeMember
+import com.alloon.alloonserver.domain.challenge.ChallengeMemberRepository
+import com.alloon.alloonserver.domain.challenge.ChallengeRepository
 import com.alloon.alloonserver.domain.user.Contact
 import com.alloon.alloonserver.domain.user.User
 import com.alloon.alloonserver.domain.user.UserRepository
@@ -16,6 +18,8 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.SliceImpl
 import org.springframework.mock.web.MockMultipartFile
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.ContextConfiguration
@@ -99,17 +103,9 @@ class ChallengeServiceTest : AbstractMailProperties {
     @Test
     fun givenValid_whenFindPopularChallenges_thenReturn() {
         // given
-        val challenge = FindPopularChallengesDto(
-            1L,
-            "챌린지 이름",
-            LocalDate.of(2024, 12, 1),
-            "https://url.kr/5MhHhD",
-            listOf("해시태그 1", "해시태그 2")
-        )
+        val dto = getFindChallengesDto()
 
-        every { challengeRepository.findPopular() } returns listOf(
-            challenge, challenge, challenge, challenge
-        )
+        every { challengeRepository.findPopular() } returns listOf(dto, dto, dto, dto)
 
         // when
         val result = challengeService.findPopularChallenges()
@@ -207,6 +203,28 @@ class ChallengeServiceTest : AbstractMailProperties {
         assertThat(result.size).isEqualTo(1)
     }
 
+    @DisplayName("모든 챌린지 조회를 하면 페이징 객체를 반환한다.")
+    @Test
+    fun givenValid_whenFindAllChallenges_thenReturn() {
+        // given
+        val dto = getFindChallengesDto()
+        val content = listOf(dto, dto, dto)
+        val pageable = PageRequest.of(0, 10)
+        val hasNext = true
+
+        every { challengeRepository.findAllOrderByEndDate(any()) } returns SliceImpl(
+            content,
+            pageable,
+            hasNext
+        )
+
+        // when
+        val result = challengeService.findAllChallenges(pageable)
+
+        // then
+        assertThat(result.content.size).isEqualTo(3)
+    }
+
     private fun getUser(): User {
         val contact = Contact(1L, "tester@photi.com", "000000", true)
         return User(1L, contact, "tester", "password1!", "")
@@ -243,6 +261,16 @@ class ChallengeServiceTest : AbstractMailProperties {
             "챌린지 목표입니다.",
             LocalDate.now(),
             LocalDate.of(2024, 12, 1),
+        )
+    }
+
+    private fun getFindChallengesDto(): FindPopularChallengesDto {
+        return FindPopularChallengesDto(
+            1L,
+            "챌린지 이름",
+            LocalDate.of(2024, 12, 1),
+            "https://url.kr/5MhHhD",
+            listOf("해시태그 1", "해시태그 2")
         )
     }
 }


### PR DESCRIPTION
## 📋 이슈 번호
- close #97 
  </br>

## 🛠 구현 사항
- 종료 날짜 최신순으로 모든 챌린지 조회
- 페이징 - Slice 사용하여 구현
- SliceResponse 생성
- controller, service 테스트 코드 구현
  </br>

## 📚 기타
- 
  </br>