### PR TITLE
[feat] 챌린지 개별 조회 API

### DIFF
--- a/.github/workflows/develop-pull-ci.yaml
+++ b/.github/workflows/develop-pull-ci.yaml
@@ -59,7 +59,7 @@ jobs:
         run: echo "${{ steps.jacoco_reporter.outputs.coverageSummary }}" >> $GITHUB_STEP_SUMMARY
 
       - name: Upload Code Coverage Artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: code-coverage-report-html
           path: build/reports/jacoco/test/html

--- a/src/main/kotlin/com/alloon/alloonserver/api/controller/challenge/ChallengeController.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/api/controller/challenge/ChallengeController.kt
@@ -139,7 +139,7 @@ class ChallengeController(
     }
 
     @GetMapping("/{challengeId}")
-    @Operation(summary = "챌린지 개별 조회")
+    @Operation(summary = "챌린지 개별 조회", description = "챌린지 파티원 이미지는 최대 3개 조회됩니다.")
     @ApiResponse(responseCode = "200")
     @ApiErrorResponses([CHALLENGE_NOT_FOUND])
     fun findChallenge(

--- a/src/main/kotlin/com/alloon/alloonserver/api/controller/challenge/ChallengeController.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/api/controller/challenge/ChallengeController.kt
@@ -2,10 +2,7 @@ package com.alloon.alloonserver.api.controller.challenge
 
 import com.alloon.alloonserver.api.controller.challenge.request.CreateChallengeRequest
 import com.alloon.alloonserver.api.controller.challenge.request.UpdateChallengeMemberGoalRequest
-import com.alloon.alloonserver.api.controller.challenge.response.CreateChallengeResponse
-import com.alloon.alloonserver.api.controller.challenge.response.FindChallengeInfoResponse
-import com.alloon.alloonserver.api.controller.challenge.response.FindChallengeMembersResponse
-import com.alloon.alloonserver.api.controller.challenge.response.FindChallengesResponse
+import com.alloon.alloonserver.api.controller.challenge.response.*
 import com.alloon.alloonserver.common.constant.ExceptionCode.*
 import com.alloon.alloonserver.common.response.ApiErrorResponses
 import com.alloon.alloonserver.common.response.CollectionSuccessResponse
@@ -137,6 +134,19 @@ class ChallengeController(
     ): ResponseEntity<SliceResponse<FindChallengesResponse>> {
         val challenges = challengeService.findAllChallenges(PageRequest.of(page, size))
         val response = SliceResponse.of(challenges)
+
+        return ResponseEntity.ok(response)
+    }
+
+    @GetMapping("/{challengeId}")
+    @Operation(summary = "챌린지 개별 조회")
+    @ApiResponse(responseCode = "200")
+    @ApiErrorResponses([CHALLENGE_NOT_FOUND])
+    fun findChallenge(
+        @PathVariable @Parameter(description = "챌린지 id", example = "1") challengeId: Long,
+    ): ResponseEntity<FindChallengeResponse> {
+        val challenge = challengeService.findChallenge(challengeId)
+        val response = FindChallengeResponse.of(challenge)
 
         return ResponseEntity.ok(response)
     }

--- a/src/main/kotlin/com/alloon/alloonserver/api/controller/challenge/ChallengeController.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/api/controller/challenge/ChallengeController.kt
@@ -139,7 +139,7 @@ class ChallengeController(
     }
 
     @GetMapping("/{challengeId}")
-    @Operation(summary = "챌린지 개별 조회", description = "챌린지 파티원 이미지는 최대 3개 조회됩니다.")
+    @Operation(summary = "챌린지 개별 조회", description = "챌린지 파티원 이미지는 최근 가입순으로 최대 3개 조회됩니다.")
     @ApiResponse(responseCode = "200")
     @ApiErrorResponses([CHALLENGE_NOT_FOUND])
     fun findChallenge(

--- a/src/main/kotlin/com/alloon/alloonserver/api/controller/challenge/request/CreateChallengeHashtagRequest.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/api/controller/challenge/request/CreateChallengeHashtagRequest.kt
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.Size
 
-@Schema(description = "챌린지 해시태그")
+@Schema(description = "챌린지 해시태그 요청 객체")
 data class CreateChallengeHashtagRequest(
 
     @field:NotBlank(message = "해시태그는 필수 입력입니다.")

--- a/src/main/kotlin/com/alloon/alloonserver/api/controller/challenge/request/CreateChallengeRuleRequest.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/api/controller/challenge/request/CreateChallengeRuleRequest.kt
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.Size
 
-@Schema(description = "챌린지 인증 룰")
+@Schema(description = "챌린지 인증 룰 요청 객체")
 data class CreateChallengeRuleRequest(
 
     @field:NotBlank(message = "인증 룰은 필수 입력입니다.")

--- a/src/main/kotlin/com/alloon/alloonserver/api/controller/challenge/response/ChallengeHashtagResponse.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/api/controller/challenge/response/ChallengeHashtagResponse.kt
@@ -15,5 +15,9 @@ data class ChallengeHashtagResponse(
         fun of(challengeHashtag: ChallengeHashtagDto): ChallengeHashtagResponse {
             return ChallengeHashtagResponse(challengeHashtag.hashtag)
         }
+
+        fun of(challengeHashtags: List<ChallengeHashtagDto>): List<ChallengeHashtagResponse> {
+            return challengeHashtags.map { of(it) }
+        }
     }
 }

--- a/src/main/kotlin/com/alloon/alloonserver/api/controller/challenge/response/ChallengeMemberImageResponse.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/api/controller/challenge/response/ChallengeMemberImageResponse.kt
@@ -1,0 +1,23 @@
+package com.alloon.alloonserver.api.controller.challenge.response
+
+import com.alloon.alloonserver.service.challenge.dto.ChallengeMemberImageDto
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "챌린지 파티원 이미지 응답 객체")
+data class ChallengeMemberImageResponse(
+
+    @Schema(description = "챌린지 파티원 이미지")
+    val memberImage: String,
+) {
+
+    companion object {
+
+        fun of(challengeMemberImage: ChallengeMemberImageDto): ChallengeMemberImageResponse {
+            return ChallengeMemberImageResponse(challengeMemberImage.imageUrl)
+        }
+
+        fun of(challengeMemberImages: List<ChallengeMemberImageDto>): List<ChallengeMemberImageResponse> {
+            return challengeMemberImages.map { of(it) }
+        }
+    }
+}

--- a/src/main/kotlin/com/alloon/alloonserver/api/controller/challenge/response/ChallengeRuleResponse.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/api/controller/challenge/response/ChallengeRuleResponse.kt
@@ -15,5 +15,9 @@ data class ChallengeRuleResponse(
         fun of(challengeRule: ChallengeRuleDto): ChallengeRuleResponse {
             return ChallengeRuleResponse(challengeRule.rule)
         }
+
+        fun of(challengeRules: List<ChallengeRuleDto>): List<ChallengeRuleResponse> {
+            return challengeRules.map { of(it) }
+        }
     }
 }

--- a/src/main/kotlin/com/alloon/alloonserver/api/controller/challenge/response/CreateChallengeResponse.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/api/controller/challenge/response/CreateChallengeResponse.kt
@@ -61,12 +61,8 @@ data class CreateChallengeResponse(
                 challenge.proveTime,
                 challenge.endDate,
                 challenge.imageUrl,
-                challenge.rules.map {
-                    ChallengeRuleResponse.of(it)
-                },
-                challenge.hashtags.map {
-                    ChallengeHashtagResponse.of(it)
-                }
+                ChallengeRuleResponse.of(challenge.rules),
+                ChallengeHashtagResponse.of(challenge.hashtags)
             )
         }
     }

--- a/src/main/kotlin/com/alloon/alloonserver/api/controller/challenge/response/FindChallengeInfoResponse.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/api/controller/challenge/response/FindChallengeInfoResponse.kt
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDate
 import java.time.LocalTime
 
+@Schema(description = "챌린지 소개 조회 응답 객체")
 data class FindChallengeInfoResponse(
 
     @Schema(
@@ -39,9 +40,7 @@ data class FindChallengeInfoResponse(
 
         fun of(challengeInfo: FindChallengeInfoDto): FindChallengeInfoResponse {
             return FindChallengeInfoResponse(
-                challengeInfo.rules.map {
-                    ChallengeRuleResponse.of(it)
-                },
+                ChallengeRuleResponse.of(challengeInfo.rules),
                 challengeInfo.proveTime,
                 challengeInfo.goal,
                 challengeInfo.startDate,

--- a/src/main/kotlin/com/alloon/alloonserver/api/controller/challenge/response/FindChallengeMembersResponse.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/api/controller/challenge/response/FindChallengeMembersResponse.kt
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDate
 import java.time.temporal.ChronoUnit
 
+@Schema(description = "챌린지 파티원 조회 응답 객체")
 data class FindChallengeMembersResponse(
 
     @Schema(description = "파티원 식별자", example = "1")

--- a/src/main/kotlin/com/alloon/alloonserver/api/controller/challenge/response/FindChallengeResponse.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/api/controller/challenge/response/FindChallengeResponse.kt
@@ -52,6 +52,17 @@ data class FindChallengeResponse(
     """
     )
     val hashtags: List<ChallengeHashtagResponse>,
+
+    @Schema(
+        description = "챌린지 파티원 이미지 리스트", example = """
+        [
+            {"memberImage": "https://url.kr/5MhHhD"},
+            {"memberImage": "https://url.kr/5MhHhD"},
+            {"memberImage": "https://url.kr/5MhHhD"}
+        ]
+    """
+    )
+    val memberImages: List<ChallengeMemberImageResponse>,
 ) {
 
     companion object {
@@ -67,6 +78,7 @@ data class FindChallengeResponse(
                 challenge.endDate,
                 ChallengeRuleResponse.of(challenge.rules),
                 ChallengeHashtagResponse.of(challenge.hashtags),
+                ChallengeMemberImageResponse.of(challenge.memberImages),
             )
         }
     }

--- a/src/main/kotlin/com/alloon/alloonserver/api/controller/challenge/response/FindChallengeResponse.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/api/controller/challenge/response/FindChallengeResponse.kt
@@ -1,0 +1,73 @@
+package com.alloon.alloonserver.api.controller.challenge.response
+
+import com.alloon.alloonserver.service.challenge.dto.FindChallengeDto
+import com.fasterxml.jackson.annotation.JsonFormat
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDate
+import java.time.LocalTime
+
+@Schema(description = "챌린지 개별 조회 응답 객체")
+data class FindChallengeResponse(
+
+    @Schema(description = "챌린지 이름", example = "신나게 하는 러닝 챌린지")
+    val name: String,
+
+    @Schema(description = "챌린지 목표", example = "하루에 한 번씩 꼭 러닝을 하는 것이 우리 챌린지의 목표입니다.")
+    val goal: String,
+
+    @Schema(description = "챌린지 대표 이미지", example = "https://url.kr/5MhHhD")
+    val imageUrl: String,
+
+    @Schema(description = "챌린지 파티원 수", example = "5")
+    val currentMemberCnt: Int,
+
+    @Schema(description = "챌린지 공개 여부", example = "true")
+    val isPublic: Boolean,
+
+    @Schema(description = "챌린지 인증 시간", example = "13:00")
+    @field:JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "kk:mm")
+    val proveTime: LocalTime,
+
+    @Schema(description = "챌린지 종료 날짜", example = "2024-12-01")
+    @field:JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+    val endDate: LocalDate,
+
+    @Schema(
+        description = "챌린지 인증 룰 리스트", example = """
+        [
+            {"rule": "장소 나오게 찍기"},
+            {"rule": "일주일에 3회 이상 인증하기"},
+            {"rule": "얼굴 안 나오게 찍기"}
+        ]
+    """
+    )
+    val rules: List<ChallengeRuleResponse>,
+
+    @Schema(
+        description = "챌린지 해시태그 리스트", example = """
+        [
+            {"hashtag": "러닝"},
+            {"hashtag": "건강"}
+        ]
+    """
+    )
+    val hashtags: List<ChallengeHashtagResponse>,
+) {
+
+    companion object {
+
+        fun of(challenge: FindChallengeDto): FindChallengeResponse {
+            return FindChallengeResponse(
+                challenge.name,
+                challenge.goal,
+                challenge.imageUrl,
+                challenge.currentMemberCnt,
+                challenge.isPublic,
+                challenge.proveTime,
+                challenge.endDate,
+                ChallengeRuleResponse.of(challenge.rules),
+                ChallengeHashtagResponse.of(challenge.hashtags),
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/alloon/alloonserver/api/controller/challenge/response/FindChallengesResponse.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/api/controller/challenge/response/FindChallengesResponse.kt
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonFormat
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDate
 
-@Schema(description = "챌린지 응답 객체")
+@Schema(description = "챌린지 조회 응답 객체")
 data class FindChallengesResponse(
 
     @Schema(description = "챌린지 id", example = "1")

--- a/src/main/kotlin/com/alloon/alloonserver/domain/challenge/Challenge.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/domain/challenge/Challenge.kt
@@ -47,7 +47,7 @@ class Challenge(
 
     //TODO redis 사용하면 hyperlog 로 변경 필요함.
     @Column(nullable = false)
-    val visitCnt: Int = 0,
+    var visitCnt: Int = 0,
 
     @Column(nullable = false)
     val isRecruit: Boolean = true,
@@ -56,5 +56,9 @@ class Challenge(
     fun addChallengeRule(rule: ChallengeRule) {
         rules.add(rule)
         rule.challenge = this
+    }
+
+    fun updateVisitCnt() {
+        visitCnt += 1
     }
 }

--- a/src/main/kotlin/com/alloon/alloonserver/domain/challenge/custom/ChallengeMemberCustomRepository.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/domain/challenge/custom/ChallengeMemberCustomRepository.kt
@@ -1,6 +1,7 @@
 package com.alloon.alloonserver.domain.challenge.custom
 
 import com.alloon.alloonserver.domain.challenge.ChallengeMember
+import com.alloon.alloonserver.service.challenge.dto.ChallengeMemberImageDto
 import com.alloon.alloonserver.service.challenge.dto.FindChallengeMembersDto
 
 interface ChallengeMemberCustomRepository {
@@ -10,4 +11,6 @@ interface ChallengeMemberCustomRepository {
     fun findByUserIdAndChallengeId(userId: Long, challengeId: Long): ChallengeMember?
 
     fun findAllByChallengeId(userId: Long, challengeId: Long): List<FindChallengeMembersDto>
+
+    fun findImagesByChallengeId(challengeId: Long): List<ChallengeMemberImageDto>
 }

--- a/src/main/kotlin/com/alloon/alloonserver/domain/challenge/custom/ChallengeMemberCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/domain/challenge/custom/ChallengeMemberCustomRepositoryImpl.kt
@@ -4,7 +4,9 @@ import com.alloon.alloonserver.domain.base.ServiceStatus
 import com.alloon.alloonserver.domain.base.ServiceStatus.ACTIVE
 import com.alloon.alloonserver.domain.challenge.ChallengeMember
 import com.alloon.alloonserver.domain.challenge.QChallengeMember.challengeMember
+import com.alloon.alloonserver.service.challenge.dto.ChallengeMemberImageDto
 import com.alloon.alloonserver.service.challenge.dto.FindChallengeMembersDto
+import com.alloon.alloonserver.service.challenge.dto.QChallengeMemberImageDto
 import com.alloon.alloonserver.service.challenge.dto.QFindChallengeMembersDto
 import com.querydsl.core.types.dsl.BooleanExpression
 import com.querydsl.core.types.dsl.CaseBuilder
@@ -38,7 +40,10 @@ class ChallengeMemberCustomRepositoryImpl(
             .fetchFirst()
     }
 
-    override fun findAllByChallengeId(userId: Long, challengeId: Long): List<FindChallengeMembersDto> {
+    override fun findAllByChallengeId(
+        userId: Long,
+        challengeId: Long
+    ): List<FindChallengeMembersDto> {
         val spec = CaseBuilder()
             .`when`(challengeMember.isCreator.isTrue).then(1)
             .`when`(challengeMember.user.id.eq(userId)).then(2)
@@ -61,6 +66,16 @@ class ChallengeMemberCustomRepositoryImpl(
                 spec.asc(),
                 challengeMember.createDateTime.asc()
             )
+            .fetch()
+    }
+
+    override fun findImagesByChallengeId(challengeId: Long): List<ChallengeMemberImageDto> {
+        return queryFactory
+            .select(QChallengeMemberImageDto(challengeMember.user.imageUrl))
+            .from(challengeMember)
+            .where(challengeMember.challenge.id.eq(challengeId))
+            .orderBy(challengeMember.createDateTime.desc())
+            .limit(3)
             .fetch()
     }
 

--- a/src/main/kotlin/com/alloon/alloonserver/service/challenge/ChallengeService.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/service/challenge/ChallengeService.kt
@@ -84,8 +84,9 @@ class ChallengeService(
         val challenge = challengeRepository.findInfoById(challengeId) ?: throw CustomException(
             CHALLENGE_NOT_FOUND
         )
+        val memberImages = challengeMemberRepository.findImagesByChallengeId(challengeId)
         challenge.updateVisitCnt()
 
-        return FindChallengeDto.of(challenge)
+        return FindChallengeDto.of(challenge, memberImages)
     }
 }

--- a/src/main/kotlin/com/alloon/alloonserver/service/challenge/ChallengeService.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/service/challenge/ChallengeService.kt
@@ -78,4 +78,14 @@ class ChallengeService(
         return challengeRepository.findAllOrderByEndDate(pageable)
             .map { FindChallengesResponse.of(it) }
     }
+
+    @Transactional
+    fun findChallenge(challengeId: Long): FindChallengeDto {
+        val challenge = challengeRepository.findInfoById(challengeId) ?: throw CustomException(
+            CHALLENGE_NOT_FOUND
+        )
+        challenge.updateVisitCnt()
+
+        return FindChallengeDto.of(challenge)
+    }
 }

--- a/src/main/kotlin/com/alloon/alloonserver/service/challenge/dto/ChallengeMemberImageDto.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/service/challenge/dto/ChallengeMemberImageDto.kt
@@ -1,0 +1,7 @@
+package com.alloon.alloonserver.service.challenge.dto
+
+import com.querydsl.core.annotations.QueryProjection
+
+data class ChallengeMemberImageDto @QueryProjection constructor(
+    val imageUrl: String,
+)

--- a/src/main/kotlin/com/alloon/alloonserver/service/challenge/dto/FindChallengeDto.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/service/challenge/dto/FindChallengeDto.kt
@@ -1,0 +1,35 @@
+package com.alloon.alloonserver.service.challenge.dto
+
+import com.alloon.alloonserver.domain.challenge.Challenge
+import java.time.LocalDate
+import java.time.LocalTime
+
+data class FindChallengeDto(
+    val name: String,
+    val goal: String,
+    val imageUrl: String,
+    val currentMemberCnt: Int,
+    val isPublic: Boolean,
+    val proveTime: LocalTime,
+    val endDate: LocalDate,
+    val rules: List<ChallengeRuleDto>,
+    val hashtags: List<ChallengeHashtagDto>,
+) {
+
+    companion object {
+
+        fun of(challenge: Challenge): FindChallengeDto {
+            return FindChallengeDto(
+                challenge.name,
+                challenge.goal,
+                challenge.imageUrl,
+                challenge.currentMemberCnt,
+                challenge.isPublic,
+                challenge.proveTime,
+                challenge.endDate,
+                ChallengeRuleDto.of(challenge.rules),
+                ChallengeHashtagDto.of(challenge.hashtags),
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/alloon/alloonserver/service/challenge/dto/FindChallengeDto.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/service/challenge/dto/FindChallengeDto.kt
@@ -14,11 +14,15 @@ data class FindChallengeDto(
     val endDate: LocalDate,
     val rules: List<ChallengeRuleDto>,
     val hashtags: List<ChallengeHashtagDto>,
+    val memberImages: List<ChallengeMemberImageDto>,
 ) {
 
     companion object {
 
-        fun of(challenge: Challenge): FindChallengeDto {
+        fun of(
+            challenge: Challenge,
+            memberImages: List<ChallengeMemberImageDto>
+        ): FindChallengeDto {
             return FindChallengeDto(
                 challenge.name,
                 challenge.goal,
@@ -29,6 +33,7 @@ data class FindChallengeDto(
                 challenge.endDate,
                 ChallengeRuleDto.of(challenge.rules),
                 ChallengeHashtagDto.of(challenge.hashtags),
+                memberImages,
             )
         }
     }

--- a/src/test/kotlin/com/alloon/alloonserver/api/controller/challenge/ChallengeControllerTest.kt
+++ b/src/test/kotlin/com/alloon/alloonserver/api/controller/challenge/ChallengeControllerTest.kt
@@ -193,6 +193,21 @@ class ChallengeControllerTest : RestDocsSupport() {
         resultActions.andExpect(status().isOk)
     }
 
+    @DisplayName("챌린지 개별 조회를 성공하면 200을 반환한다")
+    @Test
+    fun givenValid_whenFindAllChallenge_thenReturn200() {
+        // given
+        every { challengeService.findChallenge(any()) } returns getFindChallengeDto()
+
+        // when
+        val resultActions = mockMvc.perform(
+            get("/api/challenges/{challengeId}", 1)
+        )
+
+        // then
+        resultActions.andExpect(status().isOk)
+    }
+
     private fun getCreateChallengeRequest(): CreateChallengeRequest {
         return CreateChallengeRequest(
             "챌린지 이름",
@@ -233,6 +248,32 @@ class ChallengeControllerTest : RestDocsSupport() {
             LocalDate.of(2024, 12, 1),
             "https://url.kr/5MhHhD",
             listOf("해시태그 1", "해시태그 2")
+        )
+    }
+
+    private fun getFindChallengeDto(): FindChallengeDto {
+        return FindChallengeDto(
+            "챌린지 이름",
+            "챌린지 목표입니다.",
+            "https://url.kr/5MhHhD",
+            5,
+            true,
+            LocalTime.of(13, 0),
+            LocalDate.of(2024, 12, 1),
+            listOf(
+                ChallengeRuleDto("챌린지 인증 룰1"),
+                ChallengeRuleDto("챌린지 인증 룰2"),
+                ChallengeRuleDto("챌린지 인증 룰3"),
+            ),
+            listOf(
+                ChallengeHashtagDto("해시태그 1"),
+                ChallengeHashtagDto("해시태그 2"),
+            ),
+            listOf(
+                ChallengeMemberImageDto("https://url.kr/5MhHhD"),
+                ChallengeMemberImageDto("https://url.kr/5MhHhD"),
+                ChallengeMemberImageDto("https://url.kr/5MhHhD"),
+            )
         )
     }
 }

--- a/src/test/kotlin/com/alloon/alloonserver/domain/challenge/ChallengeTest.kt
+++ b/src/test/kotlin/com/alloon/alloonserver/domain/challenge/ChallengeTest.kt
@@ -1,0 +1,45 @@
+package com.alloon.alloonserver.domain.challenge
+
+import com.alloon.alloonserver.service.challenge.dto.ChallengeHashtagDto
+import com.alloon.alloonserver.service.challenge.dto.ChallengeRuleDto
+import com.alloon.alloonserver.service.challenge.dto.CreateChallengeDto
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+import java.time.LocalTime
+
+class ChallengeTest {
+
+    @DisplayName("챌린지 개별 조회시 방문 수가 증가한다.")
+    @Test
+    fun givenValid_whenUpdateVisitCnt_thenReturn() {
+        // given
+        val challenge = getCreateChallengeDto().toEntity("https://url.kr/5MhHhD")
+
+        // when
+        challenge.updateVisitCnt()
+
+        // then
+        assertThat(challenge.visitCnt).isEqualTo(1)
+    }
+
+    private fun getCreateChallengeDto(): CreateChallengeDto {
+        return CreateChallengeDto(
+            "챌린지 이름",
+            true,
+            "챌린지 목표입니다.",
+            LocalTime.of(13, 0),
+            LocalDate.of(2024, 12, 1),
+            listOf(
+                ChallengeRuleDto("챌린지 인증 룰1"),
+                ChallengeRuleDto("챌린지 인증 룰2"),
+                ChallengeRuleDto("챌린지 인증 룰3"),
+            ),
+            listOf(
+                ChallengeHashtagDto("해시태그 1"),
+                ChallengeHashtagDto("해시태그 2"),
+            )
+        )
+    }
+}

--- a/src/test/kotlin/com/alloon/alloonserver/service/challenge/ChallengeServiceTest.kt
+++ b/src/test/kotlin/com/alloon/alloonserver/service/challenge/ChallengeServiceTest.kt
@@ -225,6 +225,28 @@ class ChallengeServiceTest : AbstractMailProperties {
         assertThat(result.content.size).isEqualTo(3)
     }
 
+    @DisplayName("챌린지 개별 조회를 하면 일치하는 챌린지를 반환한다.")
+    @Test
+    fun givenValid_whenFindAllChallenge_thenReturn() {
+        // given
+        val challengeId = 1L
+        val challenge = getCreateChallengeDto().toEntity("https://url.kr/5MhHhD")
+        val dto = getFindChallengeDto()
+
+        every { challengeRepository.findInfoById(any()) } returns challenge
+        every { challengeMemberRepository.findImagesByChallengeId(any()) } returns listOf(
+            ChallengeMemberImageDto("https://url.kr/5MhHhD"),
+            ChallengeMemberImageDto("https://url.kr/5MhHhD"),
+            ChallengeMemberImageDto("https://url.kr/5MhHhD")
+        )
+
+        // when
+        val result = challengeService.findChallenge(challengeId)
+
+        // then
+        assertThat(result).isEqualTo(dto)
+    }
+
     private fun getUser(): User {
         val contact = Contact(1L, "tester@photi.com", "000000", true)
         return User(1L, contact, "tester", "password1!", "")
@@ -271,6 +293,32 @@ class ChallengeServiceTest : AbstractMailProperties {
             LocalDate.of(2024, 12, 1),
             "https://url.kr/5MhHhD",
             listOf("해시태그 1", "해시태그 2")
+        )
+    }
+
+    private fun getFindChallengeDto(): FindChallengeDto {
+        return FindChallengeDto(
+            "챌린지 이름",
+            "챌린지 목표입니다.",
+            "https://url.kr/5MhHhD",
+            1,
+            true,
+            LocalTime.of(13, 0),
+            LocalDate.of(2024, 12, 1),
+            listOf(
+                ChallengeRuleDto("챌린지 인증 룰1"),
+                ChallengeRuleDto("챌린지 인증 룰2"),
+                ChallengeRuleDto("챌린지 인증 룰3"),
+            ),
+            listOf(
+                ChallengeHashtagDto("해시태그 1"),
+                ChallengeHashtagDto("해시태그 2"),
+            ),
+            listOf(
+                ChallengeMemberImageDto("https://url.kr/5MhHhD"),
+                ChallengeMemberImageDto("https://url.kr/5MhHhD"),
+                ChallengeMemberImageDto("https://url.kr/5MhHhD"),
+            )
         )
     }
 }


### PR DESCRIPTION
## 📋 이슈 번호
- close #98 
  </br>

## 🛠 구현 사항
- 챌린지 공개 여부, 이름, 해시태그, 인증 시간, 목표, 인증 룰, 종료 날짜, 이미지, 파티원 수, 최근 가입한 파티원 이미지 조회
- 챌린지 파티원 이미지는 최근 가입순으로 최대 3개 조회
- 조회할 때마다 방문 수 증가
  </br>

## 📚 기타
- 
  </br>