### PR TITLE
[feat] 챌린지 탈퇴 API

### DIFF
--- a/src/main/kotlin/com/alloon/alloonserver/api/controller/challenge/ChallengeController.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/api/controller/challenge/ChallengeController.kt
@@ -169,4 +169,17 @@ class ChallengeController(
 
         return ResponseEntity.ok(StringSuccessResponse("챌린지 수정이 완료되었습니다."))
     }
+
+    @DeleteMapping("/{challengeId}")
+    @Operation(summary = "챌린지 탈퇴", security = [SecurityRequirement(name = ACCESS_TOKEN_KEY)])
+    @ApiResponse(responseCode = "200")
+    @ApiErrorResponses([TOKEN_UNAUTHENTICATED, TOKEN_UNAUTHORIZED, CHALLENGE_MEMBER_NOT_FOUND, CHALLENGE_NOT_FOUND])
+    fun deleteChallenge(
+        principal: Principal,
+        @PathVariable @Parameter(description = "챌린지 id", example = "1") challengeId: Long,
+    ): ResponseEntity<StringSuccessResponse> {
+        challengeService.deleteChallenge(UserUtility.getUserId(principal), challengeId)
+
+        return ResponseEntity.ok(StringSuccessResponse("챌린지 탈퇴가 완료되었습니다."))
+    }
 }

--- a/src/main/kotlin/com/alloon/alloonserver/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/config/SecurityConfig.kt
@@ -30,6 +30,7 @@ class SecurityConfig(
             .authorizeHttpRequests {
                 it.requestMatchers(POST, "/api/challenges").authenticated()
                 it.requestMatchers(PATCH, "/api/challenges/{challengeId}").authenticated()
+                it.requestMatchers(DELETE, "/api/challenges/{challengeId}").authenticated()
                 it.requestMatchers(
                     "/api/users",
                     "/api/users/token",

--- a/src/main/kotlin/com/alloon/alloonserver/domain/challenge/Challenge.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/domain/challenge/Challenge.kt
@@ -43,7 +43,7 @@ class Challenge(
     val startDate: LocalDate = LocalDate.now(),
 
     @Column(nullable = false)
-    val currentMemberCnt: Int = 1,
+    var currentMemberCnt: Int = 1,
 
     //TODO redis 사용하면 hyperlog 로 변경 필요함.
     @Column(nullable = false)
@@ -60,5 +60,9 @@ class Challenge(
 
     fun updateVisitCnt() {
         visitCnt += 1
+    }
+
+    fun decreaseCurrentMemberCnt() {
+        currentMemberCnt -= 1
     }
 }

--- a/src/main/kotlin/com/alloon/alloonserver/service/challenge/ChallengeService.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/service/challenge/ChallengeService.kt
@@ -85,7 +85,12 @@ class ChallengeService(
     }
 
     @Transactional
-    fun updateChallenge(userId: Long, challengeId: Long, dto: UpdateChallengeDto, imageFile: MultipartFile) {
+    fun updateChallenge(
+        userId: Long,
+        challengeId: Long,
+        dto: UpdateChallengeDto,
+        imageFile: MultipartFile
+    ) {
         val challenge = validateChallenge(challengeId)
         val challengeMember = validateChallengeMember(userId, challengeId)
         validateChallengeCreator(challengeMember)
@@ -95,6 +100,21 @@ class ChallengeService(
         val imageUrl = s3Service.getImageUrl(fileName)
 
         dto.updateChallenge(challenge, imageUrl)
+    }
+
+    @Transactional
+    fun deleteChallenge(userId: Long, challengeId: Long) {
+        val challenge = validateChallenge(challengeId)
+        val challengeMember = validateChallengeMember(userId, challengeId)
+
+        challengeMemberRepository.delete(challengeMember)
+
+        if (challenge.currentMemberCnt == 1) {
+            challengeRepository.deleteById(challengeId)
+            s3Service.deleteImage(challenge.imageUrl, CHALLENGES)
+        } else {
+            challenge.decreaseCurrentMemberCnt()
+        }
     }
 
     private fun validateChallenge(challengeId: Long): Challenge {

--- a/src/test/kotlin/com/alloon/alloonserver/api/controller/challenge/ChallengeControllerTest.kt
+++ b/src/test/kotlin/com/alloon/alloonserver/api/controller/challenge/ChallengeControllerTest.kt
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.SliceImpl
 import org.springframework.http.HttpHeaders.AUTHORIZATION
+import org.springframework.http.HttpMethod.DELETE
 import org.springframework.http.HttpMethod.PATCH
 import org.springframework.http.MediaType.*
 import org.springframework.mock.web.MockMultipartFile
@@ -227,6 +228,24 @@ class ChallengeControllerTest : RestDocsSupport() {
                 .header(AUTHORIZATION, "Bearer access-token")
                 .principal(mockPrincipal)
                 .contentType(MULTIPART_FORM_DATA_VALUE)
+        )
+
+        // then
+        resultActions.andExpect(status().isOk)
+    }
+
+    @DisplayName("챌린지 탈퇴를 성공하면 200을 반환한다.")
+    @Test
+    fun givenValid_whenDeleteChallenge_thenReturn200() {
+        // given
+        every { challengeService.deleteChallenge(any(), any()) } just Runs
+
+        // when
+        val resultActions = mockMvc.perform(
+            delete("/api/challenges/{challengeId}", 1)
+                .header(AUTHORIZATION, "Bearer access-token")
+                .principal(mockPrincipal)
+                .contentType(APPLICATION_JSON)
         )
 
         // then

--- a/src/test/kotlin/com/alloon/alloonserver/service/challenge/ChallengeServiceTest.kt
+++ b/src/test/kotlin/com/alloon/alloonserver/service/challenge/ChallengeServiceTest.kt
@@ -2,7 +2,6 @@ package com.alloon.alloonserver.service.challenge
 
 import com.alloon.alloonserver.common.constant.ExceptionCode.*
 import com.alloon.alloonserver.common.response.CustomException
-import com.alloon.alloonserver.domain.challenge.Challenge
 import com.alloon.alloonserver.domain.challenge.ChallengeMember
 import com.alloon.alloonserver.domain.challenge.ChallengeMemberRepository
 import com.alloon.alloonserver.domain.challenge.ChallengeRepository
@@ -12,11 +11,9 @@ import com.alloon.alloonserver.domain.user.UserRepository
 import com.alloon.alloonserver.framework.AbstractMailProperties
 import com.alloon.alloonserver.framework.TestContainerInitializer
 import com.alloon.alloonserver.service.challenge.dto.*
+import com.alloon.alloonserver.service.s3.FolderType.CHALLENGES
 import com.alloon.alloonserver.service.s3.S3Service
-import io.mockk.Runs
-import io.mockk.every
-import io.mockk.just
-import io.mockk.mockk
+import io.mockk.*
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.DisplayName
@@ -280,6 +277,61 @@ class ChallengeServiceTest : AbstractMailProperties {
         assertThat(challenge.endDate).isEqualTo(dto.endDate)
         assertThat(challenge.rules[0].rule).isEqualTo(dto.rules[0].rule)
         assertThat(challenge.hashtags[0]).isEqualTo(dto.hashtags[0].hashtag)
+    }
+
+    @DisplayName("챌린지 파티원이 2명 이상일 때 챌린지를 탈퇴하면, 챌린지 멤버에서 삭제되고 멤버수가 감소한다.")
+    @Test
+    fun givenMultipleMembers_whenDeleteChallenge_thenDeleteChallengeMemberAndDecreaseMemberCnt() {
+        // given
+        val userId = 1L
+        val challengeId = 1L
+        val challenge = getCreateChallengeDto()
+            .toEntity("https://url.kr/5MhHhD")
+            .apply { currentMemberCnt = 3 }
+        val challengeMember = ChallengeMember(user = getUser(), challenge = challenge)
+
+        every { challengeRepository.findInfoById(any()) } returns challenge
+        every {
+            challengeMemberRepository.findByUserIdAndChallengeId(any(), any())
+        } returns challengeMember
+        every { challengeMemberRepository.delete(any()) } just Runs
+
+        // when
+        challengeService.deleteChallenge(userId, challengeId)
+
+        // then
+        verify { challengeMemberRepository.delete(challengeMember) }
+        verify(exactly = 0) { challengeRepository.deleteById(challengeId) }
+        verify(exactly = 0) { s3Service.deleteImage(challenge.imageUrl, CHALLENGES) }
+        assertThat(challenge.currentMemberCnt).isEqualTo(2)
+    }
+
+    @DisplayName("마지막 파티원이 챌린지를 탈퇴하면, 챌린지 멤버에서 삭제되고 해당 챌린지는 삭제된다.")
+    @Test
+    fun givenLastMember_whenDeleteChallenge_thenDeleteChallengeMemberAndChallenge() {
+        // given
+        val userId = 1L
+        val challengeId = 1L
+        val challenge = getCreateChallengeDto()
+            .toEntity("https://url.kr/5MhHhD")
+            .apply { currentMemberCnt = 1 }
+        val challengeMember = ChallengeMember(user = getUser(), challenge = challenge)
+
+        every { challengeRepository.findInfoById(any()) } returns challenge
+        every {
+            challengeMemberRepository.findByUserIdAndChallengeId(any(), any())
+        } returns challengeMember
+        every { challengeMemberRepository.delete(any()) } just Runs
+        every { challengeRepository.deleteById(any()) } just Runs
+        every { s3Service.deleteImage(any(), any()) } just Runs
+
+        // when
+        challengeService.deleteChallenge(userId, challengeId)
+
+        // then
+        verify { challengeMemberRepository.delete(challengeMember) }
+        verify { challengeRepository.deleteById(challengeId) }
+        verify { s3Service.deleteImage(challenge.imageUrl, CHALLENGES) }
     }
 
     private fun getUser(): User {


### PR DESCRIPTION
## 📋 이슈 번호
- close #112 
  </br>

## 🛠 구현 사항
- 현재 챌린지 파티원이 2명 이상일 경우, 챌린지 멤버에서 삭제, 멤버수 감소
- 마지막 파티원이 챌린지를 탈퇴하면, 챌린지 멤버에서 삭제, 해당 챌린지 삭제(복구 불가능)
  </br>

## 📚 기타
- 
  </br>