### PR TITLE
[feat] 챌린지 피드 인증 API

### DIFF
--- a/docker/init.sql
+++ b/docker/init.sql
@@ -38,6 +38,7 @@ CREATE TABLE users
     create_date_time            TIMESTAMP(6)              NOT NULL,
     update_date_time            TIMESTAMP(6)              NOT NULL,
     contact_id                  BIGINT                    NOT NULL,
+    feed_cnt                    INT                       NOT NULL,
     CONSTRAINT fk_user_contact FOREIGN KEY (contact_id) REFERENCES contact (contact_id),
     CONSTRAINT uq_users UNIQUE (username)
 );

--- a/src/main/kotlin/com/alloon/alloonserver/api/controller/challenge/ChallengeController.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/api/controller/challenge/ChallengeController.kt
@@ -153,7 +153,7 @@ class ChallengeController(
     @PatchMapping("/{challengeId}", consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
     @Operation(summary = "챌린지 수정", security = [SecurityRequirement(name = ACCESS_TOKEN_KEY)])
     @ApiResponse(responseCode = "200")
-    @ApiErrorResponses([TOKEN_UNAUTHENTICATED, TOKEN_UNAUTHORIZED, CHALLENGE_MEMBER_NOT_FOUND, CHALLENGE_CREATOR_FORBIDDEN, CHALLENGE_NOT_FOUND, IMAGE_TYPE_UNSUPPORTED])
+    @ApiErrorResponses([TOKEN_UNAUTHENTICATED, TOKEN_UNAUTHORIZED, CHALLENGE_MEMBER_NOT_FOUND, CHALLENGE_CREATOR_FORBIDDEN, CHALLENGE_NOT_FOUND, FILE_SIZE_EXCEED, IMAGE_TYPE_UNSUPPORTED])
     fun updateChallenge(
         principal: Principal,
         @PathVariable @Parameter(description = "챌린지 id", example = "1") challengeId: Long,
@@ -186,7 +186,7 @@ class ChallengeController(
     @PostMapping("/{challengeId}/feeds", consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
     @Operation(summary = "챌린지 피드 인증", security = [SecurityRequirement(name = ACCESS_TOKEN_KEY)])
     @ApiResponse(responseCode = "201")
-    @ApiErrorResponses([TOKEN_UNAUTHENTICATED, TOKEN_UNAUTHORIZED, CHALLENGE_MEMBER_NOT_FOUND, CHALLENGE_NOT_FOUND, EXISTING_FEED, FILE_SIZE_EXCEED, IMAGE_TYPE_UNSUPPORTED])
+    @ApiErrorResponses([TOKEN_UNAUTHENTICATED, TOKEN_UNAUTHORIZED, USER_NOT_FOUND, CHALLENGE_MEMBER_NOT_FOUND, CHALLENGE_NOT_FOUND, EXISTING_FEED, FILE_SIZE_EXCEED, IMAGE_TYPE_UNSUPPORTED])
     fun createChallengeFeed(
         principal: Principal,
         @PathVariable @Parameter(description = "챌린지 id", example = "1") challengeId: Long,

--- a/src/main/kotlin/com/alloon/alloonserver/api/controller/challenge/ChallengeController.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/api/controller/challenge/ChallengeController.kt
@@ -182,4 +182,22 @@ class ChallengeController(
 
         return ResponseEntity.ok(StringSuccessResponse("챌린지 탈퇴가 완료되었습니다."))
     }
+
+    @PostMapping("/{challengeId}/feeds", consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
+    @Operation(summary = "챌린지 피드 인증", security = [SecurityRequirement(name = ACCESS_TOKEN_KEY)])
+    @ApiResponse(responseCode = "201")
+    @ApiErrorResponses([TOKEN_UNAUTHENTICATED, TOKEN_UNAUTHORIZED, CHALLENGE_MEMBER_NOT_FOUND, CHALLENGE_NOT_FOUND, EXISTING_FEED, FILE_SIZE_EXCEED, IMAGE_TYPE_UNSUPPORTED])
+    fun createChallengeFeed(
+        principal: Principal,
+        @PathVariable @Parameter(description = "챌린지 id", example = "1") challengeId: Long,
+        @RequestPart imageFile: MultipartFile,
+    ): ResponseEntity<StringSuccessResponse> {
+        challengeService.createChallengeFeed(
+            UserUtility.getUserId(principal),
+            challengeId,
+            imageFile
+        )
+
+        return ResponseEntity.status(CREATED).body(StringSuccessResponse("챌린지 피드 인증이 완료되었습니다."))
+    }
 }

--- a/src/main/kotlin/com/alloon/alloonserver/common/constant/ExceptionCode.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/common/constant/ExceptionCode.kt
@@ -100,6 +100,7 @@ enum class ExceptionCode(
     UNAVAILABLE_USERNAME(CONFLICT, "사용 불가능한 아이디입니다."),
     EXISTING_USERNAME(CONFLICT, "이미 사용중인 아이디입니다."),
     EXISTING_USER(CONFLICT, "해당 이메일로 이미 가입된 회원이 있습니다."),
+    EXISTING_FEED(CONFLICT, "이미 오늘 피드 인증을 완료하였습니다."),
 
     /**
      * 413 Payload too large

--- a/src/main/kotlin/com/alloon/alloonserver/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/config/SecurityConfig.kt
@@ -39,6 +39,7 @@ class SecurityConfig(
                     "/api/challenges/{challengeId}/info",
                     "/api/challenges/{challengeId}/challenge-members/goal",
                     "/api/challenges/{challengeId}/challenge-members",
+                    "/api/challenges/{challengeId}/feeds",
                 ).authenticated()
                 it.anyRequest().permitAll()
             }

--- a/src/main/kotlin/com/alloon/alloonserver/domain/feed/FeedRepository.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/domain/feed/FeedRepository.kt
@@ -1,7 +1,15 @@
 package com.alloon.alloonserver.domain.feed
 
+import com.alloon.alloonserver.domain.challenge.ChallengeMember
 import com.alloon.alloonserver.domain.feed.custom.FeedCustomRepository
 import org.springframework.data.jpa.repository.JpaRepository
+import java.time.LocalDateTime
 
 interface FeedRepository : JpaRepository<Feed, Long>, FeedCustomRepository {
+
+    fun existsByChallengeMemberAndCreateDateTimeBetween(
+        challengeMember: ChallengeMember,
+        startOfDay: LocalDateTime,
+        endOfDay: LocalDateTime
+    ): Boolean
 }

--- a/src/main/kotlin/com/alloon/alloonserver/domain/user/User.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/domain/user/User.kt
@@ -27,6 +27,9 @@ class User(
 
     @Column(nullable = false)
     var temporaryPasswordYn: Boolean = false,
+
+    @Column(nullable = false)
+    var feedCnt: Int = 0,
 ) : BaseEntity() {
 
     fun resetPassword(password: String) {
@@ -41,5 +44,9 @@ class User(
 
     fun changeImageUrl(imageUrl: String) {
         this.imageUrl = imageUrl
+    }
+
+    fun updateFeedCnt() {
+        feedCnt += 1
     }
 }

--- a/src/main/kotlin/com/alloon/alloonserver/service/challenge/ChallengeService.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/service/challenge/ChallengeService.kt
@@ -4,15 +4,21 @@ import com.alloon.alloonserver.api.controller.challenge.response.FindChallengesR
 import com.alloon.alloonserver.common.constant.ExceptionCode.*
 import com.alloon.alloonserver.common.response.CustomException
 import com.alloon.alloonserver.domain.challenge.*
+import com.alloon.alloonserver.domain.feed.Feed
+import com.alloon.alloonserver.domain.feed.FeedRepository
 import com.alloon.alloonserver.domain.user.UserRepository
 import com.alloon.alloonserver.service.challenge.dto.*
 import com.alloon.alloonserver.service.s3.FolderType.CHALLENGES
+import com.alloon.alloonserver.service.s3.FolderType.FEEDS
 import com.alloon.alloonserver.service.s3.S3Service
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Slice
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.multipart.MultipartFile
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
 
 @Service
 @Transactional(readOnly = true)
@@ -20,6 +26,7 @@ class ChallengeService(
     private val challengeRepository: ChallengeRepository,
     private val challengeMemberRepository: ChallengeMemberRepository,
     private val userRepository: UserRepository,
+    private val feedRepository: FeedRepository,
     private val s3Service: S3Service,
 ) {
 
@@ -117,6 +124,23 @@ class ChallengeService(
         }
     }
 
+    @Transactional
+    fun createChallengeFeed(userId: Long, challengeId: Long, imageFile: MultipartFile) {
+        val user = userRepository.find(userId) ?: throw CustomException(USER_NOT_FOUND)
+        val challenge = validateChallenge(challengeId)
+        val challengeMember = validateChallengeMember(userId, challengeId)
+        validateChallengeMemberFeed(challengeMember)
+
+        val fileName = s3Service.uploadImage(imageFile, FEEDS, challengeId)
+        val imageUrl = s3Service.getImageUrl(fileName)
+        val feed = Feed(
+            challengeMember = challengeMember, challenge = challenge, imageUrl = imageUrl
+        )
+
+        feedRepository.save(feed)
+        user.updateFeedCnt()
+    }
+
     private fun validateChallenge(challengeId: Long): Challenge {
         return challengeRepository.findInfoById(challengeId)
             ?: throw CustomException(CHALLENGE_NOT_FOUND)
@@ -130,6 +154,20 @@ class ChallengeService(
     private fun validateChallengeCreator(challengeMember: ChallengeMember) {
         if (!challengeMember.isCreator) {
             throw CustomException(CHALLENGE_CREATOR_FORBIDDEN)
+        }
+    }
+
+    private fun validateChallengeMemberFeed(challengeMember: ChallengeMember) {
+        val startOfDay = LocalDate.now().atStartOfDay()
+        val endOfDay = LocalDateTime.of(LocalDate.now(), LocalTime.MAX)
+        val isFeedCreated = feedRepository.existsByChallengeMemberAndCreateDateTimeBetween(
+            challengeMember,
+            startOfDay,
+            endOfDay
+        )
+
+        if (isFeedCreated) {
+            throw CustomException(EXISTING_FEED)
         }
     }
 }

--- a/src/main/kotlin/com/alloon/alloonserver/service/s3/FolderType.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/service/s3/FolderType.kt
@@ -1,5 +1,5 @@
 package com.alloon.alloonserver.service.s3
 
 enum class FolderType {
-    USERS, CHALLENGES, CHALLENGE_EXAMPLES
+    USERS, CHALLENGES, CHALLENGE_EXAMPLES, FEEDS
 }

--- a/src/main/kotlin/com/alloon/alloonserver/service/s3/S3Service.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/service/s3/S3Service.kt
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Service
 import org.springframework.web.multipart.MultipartFile
 import java.io.IOException
 import java.net.URLDecoder
+import java.time.LocalDate
 import kotlin.text.Charsets.UTF_8
 
 @Service
@@ -28,10 +29,17 @@ class S3Service(private val amazonS3Client: AmazonS3Client) {
     @Value("\${cloud.aws.s3.folder.folderName2}")
     private lateinit var challengeFolder: String
 
-    fun uploadImage(file: MultipartFile, folderType: FolderType): String {
+    @Value("\${cloud.aws.s3.folder.folderName3}")
+    private lateinit var feedFolder: String
+
+    fun uploadImage(
+        file: MultipartFile,
+        folderType: FolderType,
+        subFolder: Long? = null
+    ): String {
         file.validateFile()
 
-        val fileName = getRoot(folderType) + file.createFileName()
+        val fileName = getRoot(folderType, subFolder) + file.createFileName()
 
         val objectMetadata = ObjectMetadata().apply {
             contentLength = file.size
@@ -72,11 +80,12 @@ class S3Service(private val amazonS3Client: AmazonS3Client) {
         }
     }
 
-    private fun getRoot(folderType: FolderType): String {
+    private fun getRoot(folderType: FolderType, subFolder: Long? = null): String {
         return when (folderType) {
             USERS -> userFolder
             CHALLENGES -> challengeFolder
             CHALLENGE_EXAMPLES -> challengeFolder + "examples"
+            FEEDS -> feedFolder + "$subFolder/${LocalDate.now()}/"
         }
     }
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -42,6 +42,7 @@ cloud:
       folder:
         folderName1: users/
         folderName2: challenges/
+        folderName3: feeds/
     stack:
       auto: false
 

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -58,6 +58,7 @@ cloud:
       folder:
         folderName1: users/
         folderName2: challenges/
+        folderName3: feeds/
     stack:
       auto: false
 

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -38,6 +38,7 @@ CREATE TABLE users
     create_date_time            TIMESTAMP(6)              NOT NULL,
     update_date_time            TIMESTAMP(6)              NOT NULL,
     contact_id                  BIGINT                    NOT NULL,
+    feed_cnt                    INT                       NOT NULL,
     CONSTRAINT fk_user_contact FOREIGN KEY (contact_id) REFERENCES contact (contact_id),
     CONSTRAINT uq_users UNIQUE (username)
 );

--- a/src/test/kotlin/com/alloon/alloonserver/api/controller/challenge/ChallengeControllerTest.kt
+++ b/src/test/kotlin/com/alloon/alloonserver/api/controller/challenge/ChallengeControllerTest.kt
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.Test
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.SliceImpl
 import org.springframework.http.HttpHeaders.AUTHORIZATION
-import org.springframework.http.HttpMethod.DELETE
 import org.springframework.http.HttpMethod.PATCH
 import org.springframework.http.MediaType.*
 import org.springframework.mock.web.MockMultipartFile
@@ -250,6 +249,27 @@ class ChallengeControllerTest : RestDocsSupport() {
 
         // then
         resultActions.andExpect(status().isOk)
+    }
+
+    @DisplayName("챌린지 피드 인증을 성공하면 201을 반환한다.")
+    @Test
+    fun givenValid_whenCreateChallengeFeed_thenReturn201() {
+        // given
+        val multipartFile = MockMultipartFile("imageFile", "file.png", "image/png", ByteArray(1))
+
+        every { challengeService.createChallengeFeed(any(), any(), any()) } just Runs
+
+        // when
+        val resultActions = mockMvc.perform(
+            multipart("/api/challenges/{challengeId}/feeds", 1)
+                .file(multipartFile)
+                .header(AUTHORIZATION, "Bearer access-token")
+                .principal(mockPrincipal)
+                .contentType(MULTIPART_FORM_DATA_VALUE)
+        )
+
+        // then
+        resultActions.andExpect(status().isCreated)
     }
 
     private fun getCreateChallengeRequest(): CreateChallengeRequest {

--- a/src/test/kotlin/com/alloon/alloonserver/service/challenge/ChallengeServiceTest.kt
+++ b/src/test/kotlin/com/alloon/alloonserver/service/challenge/ChallengeServiceTest.kt
@@ -5,6 +5,7 @@ import com.alloon.alloonserver.common.response.CustomException
 import com.alloon.alloonserver.domain.challenge.ChallengeMember
 import com.alloon.alloonserver.domain.challenge.ChallengeMemberRepository
 import com.alloon.alloonserver.domain.challenge.ChallengeRepository
+import com.alloon.alloonserver.domain.feed.FeedRepository
 import com.alloon.alloonserver.domain.user.Contact
 import com.alloon.alloonserver.domain.user.User
 import com.alloon.alloonserver.domain.user.UserRepository
@@ -36,12 +37,14 @@ class ChallengeServiceTest : AbstractMailProperties {
     private val challengeRepository = mockk<ChallengeRepository>()
     private val challengeMemberRepository = mockk<ChallengeMemberRepository>()
     private val userRepository = mockk<UserRepository>()
+    private val feedRepository = mockk<FeedRepository>()
     private val s3Service = mockk<S3Service>()
 
     private val challengeService = ChallengeService(
         challengeRepository,
         challengeMemberRepository,
         userRepository,
+        feedRepository,
         s3Service
     )
 

--- a/src/test/kotlin/com/alloon/alloonserver/service/challenge/ChallengeServiceTest.kt
+++ b/src/test/kotlin/com/alloon/alloonserver/service/challenge/ChallengeServiceTest.kt
@@ -5,6 +5,7 @@ import com.alloon.alloonserver.common.response.CustomException
 import com.alloon.alloonserver.domain.challenge.ChallengeMember
 import com.alloon.alloonserver.domain.challenge.ChallengeMemberRepository
 import com.alloon.alloonserver.domain.challenge.ChallengeRepository
+import com.alloon.alloonserver.domain.feed.Feed
 import com.alloon.alloonserver.domain.feed.FeedRepository
 import com.alloon.alloonserver.domain.user.Contact
 import com.alloon.alloonserver.domain.user.User
@@ -335,6 +336,63 @@ class ChallengeServiceTest : AbstractMailProperties {
         verify { challengeMemberRepository.delete(challengeMember) }
         verify { challengeRepository.deleteById(challengeId) }
         verify { s3Service.deleteImage(challenge.imageUrl, CHALLENGES) }
+    }
+
+    @DisplayName("챌린지 피드 인증을 하면 피드가 저장되고, 사용자의 피드 인증 횟수가 업데이트된다.")
+    @Test
+    fun givenChallengeMember_whenCreateChallengeFeed_thenSaveFeedAndUpdateFeedCnt() {
+        // given
+        val user = getUser()
+        val imageUrl = "https://url.kr/5MhHhD"
+        val challenge = getCreateChallengeDto().toEntity(imageUrl)
+        val challengeMember = ChallengeMember(user = user, challenge = challenge)
+        val multipartFile = MockMultipartFile("file", "file.png", "image/png", ByteArray(1))
+        val feed =
+            Feed(challengeMember = challengeMember, challenge = challenge, imageUrl = imageUrl)
+
+        every { userRepository.find(any()) } returns user
+        every { challengeRepository.findInfoById(any()) } returns challenge
+        every {
+            challengeMemberRepository.findByUserIdAndChallengeId(any(), any())
+        } returns challengeMember
+        every {
+            feedRepository.existsByChallengeMemberAndCreateDateTimeBetween(any(), any(), any())
+        } returns false
+        every { s3Service.uploadImage(any(), any(), any()) } returns ""
+        every { s3Service.getImageUrl(any()) } returns imageUrl
+        every { feedRepository.save(any()) } returns feed
+
+        // when
+        challengeService.createChallengeFeed(1L, 1L, multipartFile)
+
+        // then
+        assertThat(user.feedCnt).isEqualTo(1)
+    }
+
+    @DisplayName("챌린지 파티원이 이미 오늘 챌린지 피드 인증을 했으면 예외가 발생한다.")
+    @Test
+    fun givenChallengeMemberExistingFeed_whenCreateChallengeFeed_thenThrow() {
+        // given
+        val user = getUser()
+        val imageUrl = "https://url.kr/5MhHhD"
+        val challenge = getCreateChallengeDto().toEntity(imageUrl)
+        val challengeMember = ChallengeMember(user = user, challenge = challenge)
+        val multipartFile = MockMultipartFile("file", "file.png", "image/png", ByteArray(1))
+
+        every { userRepository.find(any()) } returns user
+        every { challengeRepository.findInfoById(any()) } returns challenge
+        every {
+            challengeMemberRepository.findByUserIdAndChallengeId(any(), any())
+        } returns challengeMember
+        every {
+            feedRepository.existsByChallengeMemberAndCreateDateTimeBetween(any(), any(), any())
+        } returns true
+
+        // when & then
+        assertThatThrownBy { challengeService.createChallengeFeed(1L, 1L, multipartFile) }
+            .isInstanceOf(CustomException::class.java)
+            .extracting("exceptionCode")
+            .isEqualTo(EXISTING_FEED)
     }
 
     private fun getUser(): User {

--- a/src/test/resources/init.sql
+++ b/src/test/resources/init.sql
@@ -19,6 +19,7 @@ CREATE TABLE users
     create_date_time            TIMESTAMP(6)              NOT NULL,
     update_date_time            TIMESTAMP(6)              NOT NULL,
     contact_id                  BIGINT                    NOT NULL,
+    feed_cnt                    INT                       NOT NULL,
     CONSTRAINT fk_user_contact FOREIGN KEY (contact_id) REFERENCES contact (contact_id),
     CONSTRAINT uq_users UNIQUE (username)
 );


### PR DESCRIPTION
## 📋 이슈 번호
- close #114 
  </br>

## 🛠 구현 사항
- 피드 사진 s3 - 'feeds/챌린지 id/오늘 날짜' 에 업로드
- 챌린지 파티원이 오늘 날짜에 이미 인증했는지 확인하여 예외처리
- 피드 인증 성공 후, user의 인증 횟수 증가
  </br>

## 📚 기타
- 
  </br>