### PR TITLE
[feat] 종료된 챌린지 업데이트

### DIFF
--- a/src/main/kotlin/com/alloon/alloonserver/AlloonServerApplication.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/AlloonServerApplication.kt
@@ -2,10 +2,12 @@ package com.alloon.alloonserver
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
+import org.springframework.scheduling.annotation.EnableScheduling
 
 @SpringBootApplication
+@EnableScheduling
 class AlloonServerApplication
 
 fun main(args: Array<String>) {
-	runApplication<AlloonServerApplication>(*args)
+    runApplication<AlloonServerApplication>(*args)
 }

--- a/src/main/kotlin/com/alloon/alloonserver/common/scheduler/ScheduledTasks.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/common/scheduler/ScheduledTasks.kt
@@ -1,0 +1,16 @@
+package com.alloon.alloonserver.common.scheduler
+
+import com.alloon.alloonserver.domain.challenge.ChallengeRepository
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+
+@Component
+class ScheduledTasks(
+    private val challengeRepository: ChallengeRepository
+) {
+
+    @Scheduled(cron = "0 0 0 * * ?")
+    fun updateEndedChallenges() {
+        challengeRepository.bulkServiceStatusEnd()
+    }
+}

--- a/src/main/kotlin/com/alloon/alloonserver/domain/base/ServiceStatus.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/domain/base/ServiceStatus.kt
@@ -4,6 +4,6 @@ enum class ServiceStatus(
     val text: String,
 ) {
     ACTIVE("활성화"),
-    USER_DEL("사용자 삭제"),
+    END("종료"),
     ADMIN_DEL("관리자 삭제"),
 }

--- a/src/main/kotlin/com/alloon/alloonserver/domain/challenge/ChallengeRepository.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/domain/challenge/ChallengeRepository.kt
@@ -2,6 +2,12 @@ package com.alloon.alloonserver.domain.challenge
 
 import com.alloon.alloonserver.domain.challenge.custom.ChallengeCustomRepository
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
 
 interface ChallengeRepository : JpaRepository<Challenge, Long>, ChallengeCustomRepository {
+
+    @Modifying(clearAutomatically = true)
+    @Query("update Challenge c set c.serviceStatus = 'END' where c.endDate < current_date")
+    fun bulkServiceStatusEnd(): Int
 }

--- a/src/test/kotlin/com/alloon/alloonserver/common/scheduler/ScheduledTasksTest.kt
+++ b/src/test/kotlin/com/alloon/alloonserver/common/scheduler/ScheduledTasksTest.kt
@@ -1,0 +1,65 @@
+package com.alloon.alloonserver.common.scheduler
+
+import com.alloon.alloonserver.domain.challenge.Challenge
+import com.alloon.alloonserver.domain.challenge.ChallengeRepository
+import com.alloon.alloonserver.framework.TestContainerInitializer
+import com.alloon.alloonserver.service.challenge.dto.ChallengeHashtagDto
+import com.alloon.alloonserver.service.challenge.dto.ChallengeRuleDto
+import com.alloon.alloonserver.service.challenge.dto.CreateChallengeDto
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.ContextConfiguration
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
+import java.time.LocalTime
+
+@ActiveProfiles("test")
+@SpringBootTest
+@Transactional
+@ContextConfiguration(initializers = [TestContainerInitializer::class])
+class ScheduledTasksTest(
+    @Autowired private val challengeRepository: ChallengeRepository
+) {
+
+    @Test
+    fun givenValid_whenBulkServiceStatusEnd_thenScheduleRun() {
+        // given
+        createAndSaveChallenge(LocalDate.of(2024, 9, 20))
+        createAndSaveChallenge(LocalDate.of(2099, 1, 1))
+        createAndSaveChallenge(LocalDate.of(2022, 10, 1))
+        createAndSaveChallenge(LocalDate.now())
+
+        val result = challengeRepository.bulkServiceStatusEnd()
+
+        // when & then
+        assertThat(result).isEqualTo(2)
+    }
+
+    private fun createAndSaveChallenge(endDate: LocalDate): Challenge {
+        val dto = getCreateChallengeDto(endDate)
+        val challenge = dto.toEntity("https://url.kr/5MhHhD")
+        return challengeRepository.save(challenge)
+    }
+
+    private fun getCreateChallengeDto(endDate: LocalDate): CreateChallengeDto {
+        return CreateChallengeDto(
+            "챌린지 이름",
+            true,
+            "챌린지 목표입니다.",
+            LocalTime.of(13, 0),
+            endDate,
+            listOf(
+                ChallengeRuleDto("챌린지 인증 룰1"),
+                ChallengeRuleDto("챌린지 인증 룰2"),
+                ChallengeRuleDto("챌린지 인증 룰3"),
+            ),
+            listOf(
+                ChallengeHashtagDto("해시태그 1"),
+                ChallengeHashtagDto("해시태그 2"),
+            )
+        )
+    }
+}


### PR DESCRIPTION
## 📋 이슈 번호
- close #117 
  </br>

## 🛠 구현 사항
- 챌린지 종료 날짜가 당일 날짜를 지나면, 챌린지 서비스 상태 ACTIVE -> END 업데이트
- 벌크성 수정 쿼리 사용
- 매일 자정(00:00:00)에 스케줄러 동작
  </br>

## 📚 기타
- 
  </br>