### PR TITLE
[feat] 사용자 챌린지 기록 조회 API

### DIFF
--- a/src/main/kotlin/com/alloon/alloonserver/api/controller/user/UserController.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/api/controller/user/UserController.kt
@@ -1,5 +1,6 @@
 package com.alloon.alloonserver.api.controller.user
 
+import com.alloon.alloonserver.api.controller.user.response.UserChallengeHistoryResponse
 import com.alloon.alloonserver.api.controller.user.response.UserInfoResponse
 import com.alloon.alloonserver.common.constant.ExceptionCode.*
 import com.alloon.alloonserver.common.response.ApiErrorResponses
@@ -51,6 +52,17 @@ class UserController(
     ): ResponseEntity<UserInfoResponse> {
         val user = userService.updateUserImage(UserUtility.getUserId(principal), imageFile)
         val response = UserInfoResponse.of(user)
+
+        return ResponseEntity.ok(response)
+    }
+
+    @GetMapping("/api/users/challenge-history")
+    @Operation(summary = "사용자 챌린지 기록 조회", security = [SecurityRequirement(name = ACCESS_TOKEN_KEY)])
+    @ApiResponse(responseCode = "200")
+    @ApiErrorResponses([TOKEN_UNAUTHENTICATED, TOKEN_UNAUTHORIZED, USER_NOT_FOUND])
+    fun findUserChallengeHistory(principal: Principal): ResponseEntity<UserChallengeHistoryResponse> {
+        val challengeHistory = userService.findUserChallengeHistory(UserUtility.getUserId(principal))
+        val response = UserChallengeHistoryResponse.of(challengeHistory)
 
         return ResponseEntity.ok(response)
     }

--- a/src/main/kotlin/com/alloon/alloonserver/api/controller/user/response/UserChallengeHistoryResponse.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/api/controller/user/response/UserChallengeHistoryResponse.kt
@@ -1,0 +1,33 @@
+package com.alloon.alloonserver.api.controller.user.response
+
+import com.alloon.alloonserver.service.user.dto.UserChallengeHistoryDto
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "사용자 챌린지 기록 응답 객체")
+data class UserChallengeHistoryResponse(
+
+    @Schema(description = "사용자 아이디", example = "photi")
+    val username: String,
+
+    @Schema(description = "사용자 프로필 이미지", example = "https://url.kr/5MhHhD")
+    val imageUrl: String,
+
+    @Schema(description = "사용자 챌린지 인증 횟수", example = "99")
+    val feedCnt: Int,
+
+    @Schema(description = "사용자 종료된 챌린지 갯수", example = "2")
+    val endedChallengeCnt: Int,
+) {
+
+    companion object {
+
+        fun of(challengeHistory: UserChallengeHistoryDto): UserChallengeHistoryResponse {
+            return UserChallengeHistoryResponse(
+                challengeHistory.username,
+                challengeHistory.imageUrl,
+                challengeHistory.feedCnt,
+                challengeHistory.endedChallengeCnt,
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/alloon/alloonserver/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/config/SecurityConfig.kt
@@ -36,6 +36,7 @@ class SecurityConfig(
                     "/api/users/token",
                     "/api/users/password",
                     "/api/users/image",
+                    "/api/users/challenge-history",
                     "/api/challenges/{challengeId}/info",
                     "/api/challenges/{challengeId}/challenge-members/goal",
                     "/api/challenges/{challengeId}/challenge-members",

--- a/src/main/kotlin/com/alloon/alloonserver/domain/user/custom/UserCustomRepository.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/domain/user/custom/UserCustomRepository.kt
@@ -1,6 +1,7 @@
 package com.alloon.alloonserver.domain.user.custom
 
 import com.alloon.alloonserver.domain.user.User
+import com.alloon.alloonserver.service.user.dto.UserChallengeHistoryDto
 import com.alloon.alloonserver.service.user.dto.UserInfoDto
 
 interface UserCustomRepository {
@@ -10,4 +11,6 @@ interface UserCustomRepository {
     fun find(userId: Long): User?
 
     fun findInfoById(userId: Long): UserInfoDto?
+
+    fun findChallengeHistoryById(userId: Long): UserChallengeHistoryDto?
 }

--- a/src/main/kotlin/com/alloon/alloonserver/domain/user/custom/UserCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/domain/user/custom/UserCustomRepositoryImpl.kt
@@ -1,11 +1,16 @@
 package com.alloon.alloonserver.domain.user.custom
 
+import com.alloon.alloonserver.domain.base.ServiceStatus.END
+import com.alloon.alloonserver.domain.challenge.QChallengeMember.challengeMember
 import com.alloon.alloonserver.domain.user.QContact.contact
 import com.alloon.alloonserver.domain.user.QUser.user
 import com.alloon.alloonserver.domain.user.User
+import com.alloon.alloonserver.service.user.dto.QUserChallengeHistoryDto
 import com.alloon.alloonserver.service.user.dto.QUserInfoDto
+import com.alloon.alloonserver.service.user.dto.UserChallengeHistoryDto
 import com.alloon.alloonserver.service.user.dto.UserInfoDto
 import com.querydsl.core.types.dsl.BooleanExpression
+import com.querydsl.core.types.dsl.Expressions
 import com.querydsl.jpa.impl.JPAQueryFactory
 import org.springframework.stereotype.Repository
 
@@ -40,6 +45,32 @@ class UserCustomRepositoryImpl(
                     user.imageUrl,
                     user.username,
                     user.contact.email
+                )
+            )
+            .from(user)
+            .where(user.id.eq(userId))
+            .fetchOne()
+    }
+
+    override fun findChallengeHistoryById(userId: Long): UserChallengeHistoryDto? {
+        val endedChallengeCnt = queryFactory
+            .select(challengeMember.count())
+            .from(challengeMember)
+            .join(challengeMember.user)
+            .join(challengeMember.challenge)
+            .where(
+                challengeMember.user.id.eq(userId)
+                    .and(challengeMember.challenge.serviceStatus.eq(END))
+            )
+            .fetchOne()?.toInt() ?: 0
+
+        return queryFactory
+            .select(
+                QUserChallengeHistoryDto(
+                    user.username,
+                    user.imageUrl,
+                    user.feedCnt,
+                    Expressions.constant(endedChallengeCnt),
                 )
             )
             .from(user)

--- a/src/main/kotlin/com/alloon/alloonserver/service/user/UserService.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/service/user/UserService.kt
@@ -5,6 +5,7 @@ import com.alloon.alloonserver.common.response.CustomException
 import com.alloon.alloonserver.domain.user.UserRepository
 import com.alloon.alloonserver.service.s3.FolderType.USERS
 import com.alloon.alloonserver.service.s3.S3Service
+import com.alloon.alloonserver.service.user.dto.UserChallengeHistoryDto
 import com.alloon.alloonserver.service.user.dto.UserInfoDto
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -34,6 +35,11 @@ class UserService(
         user.changeImageUrl(imageUrl)
 
         return UserInfoDto.of(user)
+    }
+
+    fun findUserChallengeHistory(userId: Long): UserChallengeHistoryDto {
+        return userRepository.findChallengeHistoryById(userId)
+            ?: throw CustomException(USER_NOT_FOUND)
     }
 
     private fun deleteOriginalImage(imageUrl: String) {

--- a/src/main/kotlin/com/alloon/alloonserver/service/user/dto/UserChallengeHistoryDto.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/service/user/dto/UserChallengeHistoryDto.kt
@@ -1,0 +1,10 @@
+package com.alloon.alloonserver.service.user.dto
+
+import com.querydsl.core.annotations.QueryProjection
+
+data class UserChallengeHistoryDto @QueryProjection constructor(
+    val username: String,
+    val imageUrl: String,
+    val feedCnt: Int,
+    val endedChallengeCnt: Int,
+)

--- a/src/test/kotlin/com/alloon/alloonserver/api/controller/user/UserControllerTest.kt
+++ b/src/test/kotlin/com/alloon/alloonserver/api/controller/user/UserControllerTest.kt
@@ -2,6 +2,7 @@ package com.alloon.alloonserver.api.controller.user
 
 import com.alloon.alloonserver.api.controller.RestDocsSupport
 import com.alloon.alloonserver.service.user.UserService
+import com.alloon.alloonserver.service.user.dto.UserChallengeHistoryDto
 import com.alloon.alloonserver.service.user.dto.UserInfoDto
 import io.mockk.every
 import io.mockk.mockk
@@ -62,7 +63,30 @@ class UserControllerTest : RestDocsSupport() {
         resultActions.andExpect(status().isOk)
     }
 
+    @DisplayName("사용자 챌린지 기록 조회를 성공하면 200을 반환한다.")
+    @Test
+    fun givenValid_whenFindUserChallengeHistory_thenReturn200() {
+        // given
+        val dto = getUserChallengeHistoryDto()
+
+        every { userService.findUserChallengeHistory(any()) } returns dto
+
+        // when
+        val resultActions = mockMvc.perform(
+            get("/api/users/challenge-history")
+                .header(AUTHORIZATION, "Bearer access-token")
+                .principal(mockPrincipal)
+        )
+
+        // then
+        resultActions.andExpect(status().isOk)
+    }
+
     private fun getUserInfoDto(): UserInfoDto {
         return UserInfoDto("https://url.kr/5MhHhD", "tester", "tester@photi.com")
+    }
+
+    private fun getUserChallengeHistoryDto(): UserChallengeHistoryDto {
+        return UserChallengeHistoryDto("tester", "https://url.kr/5MhHhD", 99, 2)
     }
 }

--- a/src/test/kotlin/com/alloon/alloonserver/service/user/UserServiceTest.kt
+++ b/src/test/kotlin/com/alloon/alloonserver/service/user/UserServiceTest.kt
@@ -7,6 +7,7 @@ import com.alloon.alloonserver.domain.user.User
 import com.alloon.alloonserver.domain.user.UserRepository
 import com.alloon.alloonserver.framework.TestContainerInitializer
 import com.alloon.alloonserver.service.s3.S3Service
+import com.alloon.alloonserver.service.user.dto.UserChallengeHistoryDto
 import com.alloon.alloonserver.service.user.dto.UserInfoDto
 import io.mockk.Runs
 import io.mockk.every
@@ -101,6 +102,37 @@ class UserServiceTest {
             .isEqualTo(USER_NOT_FOUND)
     }
 
+    @DisplayName("사용자 챌린지 기록 조회를 하면 일치하는 사용자 챌린지 기록을 반환한다.")
+    @Test
+    fun givenValid_whenFindUserChallengeHistory_thenReturn() {
+        // given
+        val userId = 1L
+        val dto = getUserChallengeHistoryDto()
+
+        every { userRepository.findChallengeHistoryById(any()) } returns dto
+
+        // when
+        val result = userService.findUserChallengeHistory(userId)
+
+        // then
+        assertThat(result).isEqualTo(dto)
+    }
+
+    @DisplayName("존재하지 않은 사용자로 챌린지 기록 조회를 하면 예외가 발생한다.")
+    @Test
+    fun givenNotFoundUser_whenFindUserChallengeHistory_thenThrow() {
+        // given
+        val userId = 1L
+
+        every { userRepository.findChallengeHistoryById(any()) } returns null
+
+        // when & then
+        assertThatThrownBy { userService.findUserChallengeHistory(userId) }
+            .isInstanceOf(CustomException::class.java)
+            .extracting("exceptionCode")
+            .isEqualTo(USER_NOT_FOUND)
+    }
+
     private fun getUser(): User {
         val contact = Contact(1L, "tester@photi.com", "000000", true)
         return User(1L, contact, "tester", "password1!", "")
@@ -112,5 +144,9 @@ class UserServiceTest {
 
     private fun getMultipartFile(): MockMultipartFile {
         return MockMultipartFile("imageFile", "file.png", "image/png", ByteArray(1))
+    }
+
+    private fun getUserChallengeHistoryDto(): UserChallengeHistoryDto {
+        return UserChallengeHistoryDto("tester", "https://url.kr/5MhHhD", 99, 2)
     }
 }


### PR DESCRIPTION
## 📋 이슈 번호
- close #115
  </br>

## 🛠 구현 사항
- 사용자 이미지, 아이디, 챌린지 인증 횟수, 종료된 챌린지 갯수 조회
- 종료된 챌린지 갯수의 경우, 성능을 고려하여 서브 쿼리 대신, 쿼리 2개로 나눠서 실행
  </br>

## 📚 기타
- https://jojoldu.tistory.com/379
  </br>