### PR TITLE
[feat] 내 피드 조회 API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         id: jacoco
         uses: madrapps/jacoco-report@v1.7.1
         with:
-          paths: ${{ github.workspace }}/build/reports/jacoco/testCoverage/testCoverage.xml
+          paths: ${{ github.workspace }}/build/reports/jacoco/test/jacocoTestReport.xml
           token: ${{ secrets.GITHUB_TOKEN }}
           min-coverage-overall: 50
           min-coverage-changed-files: 80

--- a/build.gradle
+++ b/build.gradle
@@ -80,7 +80,7 @@ jacocoTestReport {
     reports {
         html.required = true
         csv.required = false
-        xml.required = false
+        xml.required = true
     }
 
     def qDomains = []

--- a/src/main/kotlin/com/alloon/alloonserver/api/controller/user/UserController.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/api/controller/user/UserController.kt
@@ -4,6 +4,7 @@ import com.alloon.alloonserver.api.controller.user.response.UserChallengeHistory
 import com.alloon.alloonserver.api.controller.user.response.UserInfoResponse
 import com.alloon.alloonserver.common.constant.ExceptionCode.*
 import com.alloon.alloonserver.common.response.ApiErrorResponses
+import com.alloon.alloonserver.common.response.CollectionSuccessResponse
 import com.alloon.alloonserver.common.util.UserUtility
 import com.alloon.alloonserver.config.SwaggerConfig.Companion.ACCESS_TOKEN_KEY
 import com.alloon.alloonserver.service.user.UserService
@@ -14,21 +15,19 @@ import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.MediaType.MULTIPART_FORM_DATA_VALUE
 import org.springframework.http.ResponseEntity
 import org.springframework.validation.annotation.Validated
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestPart
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 import org.springframework.web.multipart.MultipartFile
 import java.security.Principal
 
 @Validated
 @RestController
+@RequestMapping("/api/users")
 @Tag(name = "User", description = "사용자 API")
 class UserController(
     private val userService: UserService,
 ) {
 
-    @GetMapping("/api/users")
+    @GetMapping
     @Operation(summary = "사용자 정보 조회", security = [SecurityRequirement(name = ACCESS_TOKEN_KEY)])
     @ApiResponse(responseCode = "200")
     @ApiErrorResponses([TOKEN_UNAUTHENTICATED, TOKEN_UNAUTHORIZED, USER_NOT_FOUND])
@@ -39,7 +38,7 @@ class UserController(
         return ResponseEntity.ok(response)
     }
 
-    @PostMapping("/api/users/image", consumes = [MULTIPART_FORM_DATA_VALUE])
+    @PostMapping("/image", consumes = [MULTIPART_FORM_DATA_VALUE])
     @Operation(
         summary = "사용자 프로필 이미지 업로드",
         security = [SecurityRequirement(name = ACCESS_TOKEN_KEY)]
@@ -56,14 +55,28 @@ class UserController(
         return ResponseEntity.ok(response)
     }
 
-    @GetMapping("/api/users/challenge-history")
+    @GetMapping("/challenge-history")
     @Operation(summary = "사용자 챌린지 기록 조회", security = [SecurityRequirement(name = ACCESS_TOKEN_KEY)])
     @ApiResponse(responseCode = "200")
     @ApiErrorResponses([TOKEN_UNAUTHENTICATED, TOKEN_UNAUTHORIZED, USER_NOT_FOUND])
     fun findUserChallengeHistory(principal: Principal): ResponseEntity<UserChallengeHistoryResponse> {
-        val challengeHistory = userService.findUserChallengeHistory(UserUtility.getUserId(principal))
+        val challengeHistory =
+            userService.findUserChallengeHistory(UserUtility.getUserId(principal))
         val response = UserChallengeHistoryResponse.of(challengeHistory)
 
         return ResponseEntity.ok(response)
+    }
+
+    @GetMapping("/feeds")
+    @Operation(
+        summary = "사용자 피드 인증 날짜 리스트 조회",
+        security = [SecurityRequirement(name = ACCESS_TOKEN_KEY)]
+    )
+    @ApiResponse(responseCode = "200")
+    @ApiErrorResponses([TOKEN_UNAUTHENTICATED, TOKEN_UNAUTHORIZED, USER_NOT_FOUND])
+    fun findUserFeeds(principal: Principal): ResponseEntity<CollectionSuccessResponse> {
+        val response = userService.findUserFeeds(UserUtility.getUserId(principal))
+
+        return ResponseEntity.ok(CollectionSuccessResponse(response))
     }
 }

--- a/src/main/kotlin/com/alloon/alloonserver/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/config/SecurityConfig.kt
@@ -37,6 +37,7 @@ class SecurityConfig(
                     "/api/users/password",
                     "/api/users/image",
                     "/api/users/challenge-history",
+                    "/api/users/feeds",
                     "/api/challenges/{challengeId}/info",
                     "/api/challenges/{challengeId}/challenge-members/goal",
                     "/api/challenges/{challengeId}/challenge-members",

--- a/src/main/kotlin/com/alloon/alloonserver/domain/user/custom/UserCustomRepository.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/domain/user/custom/UserCustomRepository.kt
@@ -13,4 +13,6 @@ interface UserCustomRepository {
     fun findInfoById(userId: Long): UserInfoDto?
 
     fun findChallengeHistoryById(userId: Long): UserChallengeHistoryDto?
+
+    fun findFeedsById(userId: Long): List<String>?
 }

--- a/src/main/kotlin/com/alloon/alloonserver/domain/user/custom/UserCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/domain/user/custom/UserCustomRepositoryImpl.kt
@@ -2,6 +2,7 @@ package com.alloon.alloonserver.domain.user.custom
 
 import com.alloon.alloonserver.domain.base.ServiceStatus.END
 import com.alloon.alloonserver.domain.challenge.QChallengeMember.challengeMember
+import com.alloon.alloonserver.domain.feed.QFeed.feed
 import com.alloon.alloonserver.domain.user.QContact.contact
 import com.alloon.alloonserver.domain.user.QUser.user
 import com.alloon.alloonserver.domain.user.User
@@ -73,6 +74,22 @@ class UserCustomRepositoryImpl(
                     Expressions.constant(endedChallengeCnt),
                 )
             )
+            .from(user)
+            .where(user.id.eq(userId))
+            .fetchOne()
+    }
+
+    override fun findFeedsById(userId: Long): List<String>? {
+        val feeds = queryFactory
+            .select(feed.createDateTime)
+            .from(feed)
+            .join(feed.challengeMember.user)
+            .where(feed.challengeMember.user.id.eq(userId))
+            .fetch()
+            .map { it.toLocalDate().toString() }
+
+        return queryFactory
+            .select(Expressions.constant(feeds))
             .from(user)
             .where(user.id.eq(userId))
             .fetchOne()

--- a/src/main/kotlin/com/alloon/alloonserver/service/user/UserService.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/service/user/UserService.kt
@@ -42,6 +42,11 @@ class UserService(
             ?: throw CustomException(USER_NOT_FOUND)
     }
 
+    fun findUserFeeds(userId: Long): List<String> {
+        return userRepository.findFeedsById(userId)?.distinct()
+            ?: throw CustomException(USER_NOT_FOUND)
+    }
+
     private fun deleteOriginalImage(imageUrl: String) {
         if (imageUrl.isNotEmpty()) {
             s3Service.deleteImage(imageUrl, USERS)

--- a/src/test/kotlin/com/alloon/alloonserver/api/controller/user/UserControllerTest.kt
+++ b/src/test/kotlin/com/alloon/alloonserver/api/controller/user/UserControllerTest.kt
@@ -82,6 +82,25 @@ class UserControllerTest : RestDocsSupport() {
         resultActions.andExpect(status().isOk)
     }
 
+    @DisplayName("사용자 피드 인증 날짜 리스트 조회를 성공하면 200을 반환한다.")
+    @Test
+    fun givenValid_whenFindUserFeeds_thenReturn200() {
+        // given
+        val response = listOf("2024-10-02", "2024-10-05", "2024-10-07")
+
+        every { userService.findUserFeeds(any()) } returns response
+
+        // when
+        val resultActions = mockMvc.perform(
+            get("/api/users/feeds")
+                .header(AUTHORIZATION, "Bearer access-token")
+                .principal(mockPrincipal)
+        )
+
+        // then
+        resultActions.andExpect(status().isOk)
+    }
+
     private fun getUserInfoDto(): UserInfoDto {
         return UserInfoDto("https://url.kr/5MhHhD", "tester", "tester@photi.com")
     }

--- a/src/test/kotlin/com/alloon/alloonserver/service/user/UserServiceTest.kt
+++ b/src/test/kotlin/com/alloon/alloonserver/service/user/UserServiceTest.kt
@@ -133,6 +133,37 @@ class UserServiceTest {
             .isEqualTo(USER_NOT_FOUND)
     }
 
+    @DisplayName("사용자 피드 인증 날짜 리스트 조회를 하면 일치하는 사용자 피드 인증 날짜 리스트를 반환한다.")
+    @Test
+    fun givenValid_whenFindUserFeeds_thenReturn() {
+        // given
+        val userId = 1L
+        val feeds = listOf("2024-10-02", "2024-10-05", "2024-10-07")
+
+        every { userRepository.findFeedsById(any()) } returns feeds
+
+        // when
+        val result = userService.findUserFeeds(userId)
+
+        // then
+        assertThat(result).isEqualTo(feeds)
+    }
+
+    @DisplayName("존재하지 않은 사용자로 피드 인증 날짜 리스트 조회를 하면 예외가 발생한다.")
+    @Test
+    fun givenNotFoundUser_whenFindUserFeeds_thenThrow() {
+        // given
+        val userId = 1L
+
+        every { userRepository.findFeedsById(any()) } returns null
+
+        // when & then
+        assertThatThrownBy { userService.findUserFeeds(userId) }
+            .isInstanceOf(CustomException::class.java)
+            .extracting("exceptionCode")
+            .isEqualTo(USER_NOT_FOUND)
+    }
+
     private fun getUser(): User {
         val contact = Contact(1L, "tester@photi.com", "000000", true)
         return User(1L, contact, "tester", "password1!", "")


### PR DESCRIPTION
## 📋 이슈 번호
- close #120
  </br>

## 🛠 구현 사항
- 사용자가 챌린지 인증한 날짜 리스트 조회
- 피드 생성 날짜 조회, 사용자의 피드 인증 날짜 조회 쿼리 2개로 분리
  </br>

## 📚 기타
- 
  </br>