### PR TITLE
[feat] 피드 삭제 API

### DIFF
--- a/src/main/kotlin/com/alloon/alloonserver/api/controller/challenge/ChallengeController.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/api/controller/challenge/ChallengeController.kt
@@ -200,4 +200,18 @@ class ChallengeController(
 
         return ResponseEntity.status(CREATED).body(StringSuccessResponse("챌린지 피드 인증이 완료되었습니다."))
     }
+
+    @DeleteMapping("/{challengeId}/feeds/{feedId}")
+    @Operation(summary = "챌린지 피드 삭제", security = [SecurityRequirement(name = ACCESS_TOKEN_KEY)])
+    @ApiResponse(responseCode = "200")
+    @ApiErrorResponses([TOKEN_UNAUTHENTICATED, TOKEN_UNAUTHORIZED, USER_NOT_FOUND, CHALLENGE_MEMBER_NOT_FOUND, CHALLENGE_NOT_FOUND, FEED_NOT_FOUND])
+    fun deleteChallengeFeed(
+        principal: Principal,
+        @PathVariable @Parameter(description = "챌린지 id", example = "1") challengeId: Long,
+        @PathVariable @Parameter(description = "피드 id", example = "1") feedId: Long,
+    ): ResponseEntity<StringSuccessResponse> {
+        challengeService.deleteChallengeFeed(UserUtility.getUserId(principal), challengeId, feedId)
+
+        return ResponseEntity.ok(StringSuccessResponse("챌린지 피드 삭제가 완료되었습니다."))
+    }
 }

--- a/src/main/kotlin/com/alloon/alloonserver/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/config/SecurityConfig.kt
@@ -42,6 +42,7 @@ class SecurityConfig(
                     "/api/challenges/{challengeId}/challenge-members/goal",
                     "/api/challenges/{challengeId}/challenge-members",
                     "/api/challenges/{challengeId}/feeds",
+                    "/api/challenges/{challengeId}/feeds/{feedId}",
                 ).authenticated()
                 it.anyRequest().permitAll()
             }

--- a/src/main/kotlin/com/alloon/alloonserver/domain/feed/FeedRepository.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/domain/feed/FeedRepository.kt
@@ -12,4 +12,6 @@ interface FeedRepository : JpaRepository<Feed, Long>, FeedCustomRepository {
         startOfDay: LocalDateTime,
         endOfDay: LocalDateTime
     ): Boolean
+
+    fun findByIdAndChallengeMemberId(feedId: Long, challengeMemberId: Long?): Feed?
 }

--- a/src/main/kotlin/com/alloon/alloonserver/domain/user/User.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/domain/user/User.kt
@@ -51,6 +51,8 @@ class User(
     }
 
     fun decreaseFeedCnt() {
-        feedCnt -= 1
+        if (feedCnt > 0) {
+            feedCnt -= 1
+        }
     }
 }

--- a/src/main/kotlin/com/alloon/alloonserver/domain/user/User.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/domain/user/User.kt
@@ -49,4 +49,8 @@ class User(
     fun updateFeedCnt() {
         feedCnt += 1
     }
+
+    fun decreaseFeedCnt() {
+        feedCnt -= 1
+    }
 }

--- a/src/main/kotlin/com/alloon/alloonserver/service/challenge/ChallengeService.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/service/challenge/ChallengeService.kt
@@ -6,6 +6,7 @@ import com.alloon.alloonserver.common.response.CustomException
 import com.alloon.alloonserver.domain.challenge.*
 import com.alloon.alloonserver.domain.feed.Feed
 import com.alloon.alloonserver.domain.feed.FeedRepository
+import com.alloon.alloonserver.domain.user.User
 import com.alloon.alloonserver.domain.user.UserRepository
 import com.alloon.alloonserver.service.challenge.dto.*
 import com.alloon.alloonserver.service.s3.FolderType.CHALLENGES
@@ -36,7 +37,7 @@ class ChallengeService(
         dto: CreateChallengeDto,
         imageFile: MultipartFile
     ): CreateChallengeDto {
-        val user = userRepository.find(userId) ?: throw CustomException(USER_NOT_FOUND)
+        val user = validateUser(userId)
         val fileName = s3Service.uploadImage(imageFile, CHALLENGES)
         val imageUrl = s3Service.getImageUrl(fileName)
 
@@ -126,7 +127,7 @@ class ChallengeService(
 
     @Transactional
     fun createChallengeFeed(userId: Long, challengeId: Long, imageFile: MultipartFile) {
-        val user = userRepository.find(userId) ?: throw CustomException(USER_NOT_FOUND)
+        val user = validateUser(userId)
         val challenge = validateChallenge(challengeId)
         val challengeMember = validateChallengeMember(userId, challengeId)
         validateChallengeMemberFeed(challengeMember)
@@ -139,6 +140,25 @@ class ChallengeService(
 
         feedRepository.save(feed)
         user.updateFeedCnt()
+    }
+
+    @Transactional
+    fun deleteChallengeFeed(userId: Long, challengeId: Long, feedId: Long) {
+        val user = validateUser(userId)
+        validateChallenge(challengeId)
+        val challengeMemberId = validateChallengeMember(userId, challengeId).id
+        val feed = feedRepository.findByIdAndChallengeMemberId(feedId, challengeMemberId)
+            ?: throw CustomException(FEED_NOT_FOUND)
+
+        feedRepository.delete(feed)
+        s3Service.deleteImage(feed.imageUrl, FEEDS, challengeId)
+        user.decreaseFeedCnt()
+
+        // TODO 댓글, 좋아요 삭제
+    }
+
+    private fun validateUser(userId: Long): User {
+        return userRepository.find(userId) ?: throw CustomException(USER_NOT_FOUND)
     }
 
     private fun validateChallenge(challengeId: Long): Challenge {

--- a/src/main/kotlin/com/alloon/alloonserver/service/s3/S3Service.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/service/s3/S3Service.kt
@@ -14,7 +14,6 @@ import org.springframework.stereotype.Service
 import org.springframework.web.multipart.MultipartFile
 import java.io.IOException
 import java.net.URLDecoder
-import java.time.LocalDate
 import kotlin.text.Charsets.UTF_8
 
 @Service
@@ -69,9 +68,9 @@ class S3Service(private val amazonS3Client: AmazonS3Client) {
             .map { getImageUrl(it) }
     }
 
-    fun deleteImage(imageUrl: String, folderType: FolderType) {
+    fun deleteImage(imageUrl: String, folderType: FolderType, subFolder: Long? = null) {
         try {
-            val root = getRoot(folderType)
+            val root = getRoot(folderType, subFolder)
             val fileName = imageUrl.substringAfter(root)
             val decodedFileName = URLDecoder.decode(fileName, UTF_8.toString())
             amazonS3Client.deleteObject(bucket, root + decodedFileName)
@@ -85,7 +84,7 @@ class S3Service(private val amazonS3Client: AmazonS3Client) {
             USERS -> userFolder
             CHALLENGES -> challengeFolder
             CHALLENGE_EXAMPLES -> challengeFolder + "examples"
-            FEEDS -> feedFolder + "$subFolder/${LocalDate.now()}/"
+            FEEDS -> "$feedFolder$subFolder/"
         }
     }
 }

--- a/src/test/kotlin/com/alloon/alloonserver/api/controller/challenge/ChallengeControllerTest.kt
+++ b/src/test/kotlin/com/alloon/alloonserver/api/controller/challenge/ChallengeControllerTest.kt
@@ -272,6 +272,24 @@ class ChallengeControllerTest : RestDocsSupport() {
         resultActions.andExpect(status().isCreated)
     }
 
+    @DisplayName("챌린지 피드 삭제를 성공하면 200을 반환한다.")
+    @Test
+    fun givenValid_whenDeleteChallengeFeed_thenReturn200() {
+        // given
+        every { challengeService.deleteChallengeFeed(any(), any(), any()) } just Runs
+
+        // when
+        val resultActions = mockMvc.perform(
+            delete("/api/challenges/{challengeId}/feeds/{feedId}", 1, 1)
+                .header(AUTHORIZATION, "Bearer access-token")
+                .principal(mockPrincipal)
+                .contentType(APPLICATION_JSON)
+        )
+
+        // then
+        resultActions.andExpect(status().isOk)
+    }
+
     private fun getCreateChallengeRequest(): CreateChallengeRequest {
         return CreateChallengeRequest(
             "챌린지 이름",

--- a/src/test/kotlin/com/alloon/alloonserver/domain/user/UserTest.kt
+++ b/src/test/kotlin/com/alloon/alloonserver/domain/user/UserTest.kt
@@ -58,8 +58,42 @@ class UserTest {
         assertThat(user.imageUrl).isEqualTo(imageUrl)
     }
 
+    @DisplayName("피드 인증 횟수가 0보다 크면 피드 인증 횟수가 감소한다.")
+    @Test
+    fun givenFeedCntGreaterThanZero_whenDecreaseFeedCnt_thenReturn() {
+        // given
+        val contact = createContact()
+        val user = createUser(contact)
+
+        // when
+        user.decreaseFeedCnt()
+
+        // then
+        assertThat(user.feedCnt).isEqualTo(3)
+    }
+
+    @DisplayName("피드 인증 횟수가 0이면 피드 인증 횟수가 감소하지 않는다.")
+    @Test
+    fun givenFeedCntZero_whenDecreaseFeedCnt_thenReturn() {
+        // given
+        val contact = createContact()
+        val user = createUser(contact).apply { feedCnt = 0 }
+
+        // when
+        user.decreaseFeedCnt()
+
+        // then
+        assertThat(user.feedCnt).isEqualTo(0)
+    }
+
     private fun createUser(contact: Contact): User {
-        return User(contact = contact, username = "tester", password = "password1!", imageUrl = "")
+        return User(
+            contact = contact,
+            username = "tester",
+            password = "password1!",
+            imageUrl = "",
+            feedCnt = 4
+        )
     }
 
     private fun createContact(): Contact {

--- a/src/test/kotlin/com/alloon/alloonserver/service/challenge/ChallengeServiceTest.kt
+++ b/src/test/kotlin/com/alloon/alloonserver/service/challenge/ChallengeServiceTest.kt
@@ -14,6 +14,7 @@ import com.alloon.alloonserver.framework.AbstractMailProperties
 import com.alloon.alloonserver.framework.TestContainerInitializer
 import com.alloon.alloonserver.service.challenge.dto.*
 import com.alloon.alloonserver.service.s3.FolderType.CHALLENGES
+import com.alloon.alloonserver.service.s3.FolderType.FEEDS
 import com.alloon.alloonserver.service.s3.S3Service
 import io.mockk.*
 import org.assertj.core.api.Assertions.assertThat
@@ -393,6 +394,121 @@ class ChallengeServiceTest : AbstractMailProperties {
             .isInstanceOf(CustomException::class.java)
             .extracting("exceptionCode")
             .isEqualTo(EXISTING_FEED)
+    }
+
+    @DisplayName("챌린지 피드 삭제를 하면 연관된 피드, 댓글, 좋아요가 모두 삭제되고, 사용자의 피드 인증 횟수가 감소한다.")
+    @Test
+    fun givenValid_whenDeleteChallengeFeed_thenDeleteFeedAndCommentsAndLike() {
+        // given
+        val userId = 1L
+        val challengeId = 1L
+        val feedId = 1L
+        val imageUrl = "https://url.kr/5MhHhD"
+        val user = getUser()
+        val challenge = getCreateChallengeDto().toEntity(imageUrl)
+        val challengeMember = ChallengeMember(user = user, challenge = challenge)
+        val feed = Feed(1L, challengeMember, challenge, imageUrl, 1)
+
+        every { userRepository.find(any()) } returns user
+        every { challengeRepository.findInfoById(any()) } returns challenge
+        every {
+            challengeMemberRepository.findByUserIdAndChallengeId(any(), any())
+        } returns challengeMember
+        every { feedRepository.findByIdAndChallengeMemberId(any(), any()) } returns feed
+        every { feedRepository.delete(any()) } just Runs
+        every { s3Service.deleteImage(any(), any(), any()) } just Runs
+
+        // when
+        challengeService.deleteChallengeFeed(userId, challengeId, feedId)
+
+        // then
+        verify { feedRepository.delete(feed) }
+        verify { s3Service.deleteImage(feed.imageUrl, FEEDS, challengeId) }
+        assertThat(user.feedCnt).isEqualTo(0)
+    }
+
+    @DisplayName("등록되지 않은 사용자로 피드 삭제를 하면 예외가 발생한다.")
+    @Test
+    fun givenNotFoundUser_whenDeleteChallengeFeed_thenThrow() {
+        // given
+        val userId = 1L
+        val challengeId = 1L
+        val feedId = 1L
+
+        every { userRepository.find(any()) } returns null
+
+        // when & then
+        assertThatThrownBy { challengeService.deleteChallengeFeed(userId, challengeId, feedId) }
+            .isInstanceOf(CustomException::class.java)
+            .extracting("exceptionCode")
+            .isEqualTo(USER_NOT_FOUND)
+    }
+
+    @DisplayName("등록되지 않은 챌린지의 피드 삭제를 하면 예외가 발생한다.")
+    @Test
+    fun givenNotFoundChallenge_whenDeleteChallengeFeed_thenThrow() {
+        // given
+        val user = getUser()
+        val userId = 1L
+        val challengeId = 1L
+        val feedId = 1L
+
+        every { userRepository.find(any()) } returns user
+        every { challengeRepository.findInfoById(any()) } returns null
+
+        // when & then
+        assertThatThrownBy { challengeService.deleteChallengeFeed(userId, challengeId, feedId) }
+            .isInstanceOf(CustomException::class.java)
+            .extracting("exceptionCode")
+            .isEqualTo(CHALLENGE_NOT_FOUND)
+    }
+
+    @DisplayName("등록되지 않은 챌린지 파티원이 피드 삭제를 하면 예외가 발생한다.")
+    @Test
+    fun givenNotFoundChallengeMember_whenDeleteChallengeFeed_thenThrow() {
+        // given
+        val user = getUser()
+        val imageUrl = "https://url.kr/5MhHhD"
+        val challenge = getCreateChallengeDto().toEntity(imageUrl)
+        val userId = 1L
+        val challengeId = 1L
+        val feedId = 1L
+
+        every { userRepository.find(any()) } returns user
+        every { challengeRepository.findInfoById(any()) } returns challenge
+        every { challengeMemberRepository.findByUserIdAndChallengeId(any(), any()) } returns null
+
+        // when & then
+        assertThatThrownBy { challengeService.deleteChallengeFeed(userId, challengeId, feedId) }
+            .isInstanceOf(CustomException::class.java)
+            .extracting("exceptionCode")
+            .isEqualTo(CHALLENGE_MEMBER_NOT_FOUND)
+    }
+
+    @DisplayName("등록되지 않은 피드 삭제를 하면 예외가 발생한다.")
+    @Test
+    fun givenNotFoundFeed_whenDeleteChallengeFeed_thenThrow() {
+        // given
+        val user = getUser()
+        val imageUrl = "https://url.kr/5MhHhD"
+        val challenge = getCreateChallengeDto().toEntity(imageUrl)
+        val challengeMember = ChallengeMember(user = user, challenge = challenge)
+        val userId = 1L
+        val challengeId = 1L
+        val feedId = 1L
+
+        every { userRepository.find(any()) } returns user
+        every { challengeRepository.findInfoById(any()) } returns challenge
+        every {
+            challengeMemberRepository.findByUserIdAndChallengeId(any(), any())
+        } returns challengeMember
+        every { feedRepository.findByIdAndChallengeMemberId(any(), any()) } returns null
+
+        // when & then
+        assertThatThrownBy { challengeService.deleteChallengeFeed(userId, challengeId, feedId) }
+            .isInstanceOf(CustomException::class.java)
+            .extracting("exceptionCode")
+            .isEqualTo(FEED_NOT_FOUND)
     }
 
     private fun getUser(): User {


### PR DESCRIPTION
## 📋 이슈 번호
- close #126 
  </br>

## 🛠 구현 사항
- s3에서 이미지 삭제
- 사용자 피드 인증 횟수 감소 (0보다 클 경우에만)
  </br>

## 📚 기타
- 피드 댓글, 좋아요 구현 후 삭제 기능 추가
  </br>