### PR TITLE
[feat] 피드 조회 API

### DIFF
--- a/src/main/kotlin/com/alloon/alloonserver/api/controller/challenge/ChallengeController.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/api/controller/challenge/ChallengeController.kt
@@ -3,6 +3,7 @@ package com.alloon.alloonserver.api.controller.challenge
 import com.alloon.alloonserver.api.controller.challenge.request.*
 import com.alloon.alloonserver.api.controller.challenge.response.*
 import com.alloon.alloonserver.common.constant.ExceptionCode.*
+import com.alloon.alloonserver.common.constant.SortTypeConstants
 import com.alloon.alloonserver.common.response.ApiErrorResponses
 import com.alloon.alloonserver.common.response.CollectionSuccessResponse
 import com.alloon.alloonserver.common.response.SliceResponse
@@ -213,5 +214,26 @@ class ChallengeController(
         challengeService.deleteChallengeFeed(UserUtility.getUserId(principal), challengeId, feedId)
 
         return ResponseEntity.ok(StringSuccessResponse("챌린지 피드 삭제가 완료되었습니다."))
+    }
+
+    @GetMapping("/{challengeId}/feeds")
+    @Operation(
+        summary = "챌린지 피드 조회",
+        description = "정렬 기준 선택 시, 최신순[피드 인증 날짜 최신순], 인기순[반응 수(하트 수 + 댓글 수) 많은 순]으로 조회됩니다.",
+        security = [SecurityRequirement(name = ACCESS_TOKEN_KEY)]
+    )
+    @ApiResponse(responseCode = "200")
+    @ApiErrorResponses([TOKEN_UNAUTHENTICATED, TOKEN_UNAUTHORIZED])
+    fun findChallengeFeeds(
+        @PathVariable @Parameter(description = "챌린지 id", example = "1") challengeId: Long,
+        @Parameter(description = "페이지 시작 번호") @RequestParam(defaultValue = "0") page: Int,
+        @Parameter(description = "한 페이지당 content 최대 갯수") @RequestParam(defaultValue = "10") size: Int,
+        @Parameter(description = "정렬 기준") @RequestParam(defaultValue = "LATEST") sort: SortTypeConstants,
+    ): ResponseEntity<SliceResponse<FindChallengeFeedsByDateResponse>> {
+        val pageable = PageRequest.of(page, size)
+        val challengeFeeds = challengeService.findChallengeFeeds(challengeId, pageable, sort)
+        val response = SliceResponse.of(challengeFeeds)
+
+        return ResponseEntity.ok(response)
     }
 }

--- a/src/main/kotlin/com/alloon/alloonserver/api/controller/challenge/response/FindChallengeFeedsByDateResponse.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/api/controller/challenge/response/FindChallengeFeedsByDateResponse.kt
@@ -10,6 +10,9 @@ data class FindChallengeFeedsByDateResponse(
     @Schema(description = "피드 인증 날짜", example = "2024-10-09")
     val createdDate: LocalDate,
 
+    @Schema(description = "피드 인증한 파티원 수", example = "5")
+    val feedMemberCnt: Int,
+
     @Schema(description = "피드 목록")
     val feeds: List<FindChallengeFeedsResponse>
 ) {
@@ -22,6 +25,7 @@ data class FindChallengeFeedsByDateResponse(
         ): FindChallengeFeedsByDateResponse {
             return FindChallengeFeedsByDateResponse(
                 createdDate,
+                feeds.count(),
                 FindChallengeFeedsResponse.of(feeds)
             )
         }

--- a/src/main/kotlin/com/alloon/alloonserver/api/controller/challenge/response/FindChallengeFeedsByDateResponse.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/api/controller/challenge/response/FindChallengeFeedsByDateResponse.kt
@@ -1,0 +1,29 @@
+package com.alloon.alloonserver.api.controller.challenge.response
+
+import com.alloon.alloonserver.service.challenge.dto.FindChallengeFeedsDto
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDate
+
+@Schema(description = "챌린지 피드 인증 날짜별 응답 객체")
+data class FindChallengeFeedsByDateResponse(
+
+    @Schema(description = "피드 인증 날짜", example = "2024-10-09")
+    val createdDate: LocalDate,
+
+    @Schema(description = "피드 목록")
+    val feeds: List<FindChallengeFeedsResponse>
+) {
+
+    companion object {
+
+        fun of(
+            createdDate: LocalDate,
+            feeds: List<FindChallengeFeedsDto>
+        ): FindChallengeFeedsByDateResponse {
+            return FindChallengeFeedsByDateResponse(
+                createdDate,
+                FindChallengeFeedsResponse.of(feeds)
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/alloon/alloonserver/api/controller/challenge/response/FindChallengeFeedsResponse.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/api/controller/challenge/response/FindChallengeFeedsResponse.kt
@@ -1,0 +1,44 @@
+package com.alloon.alloonserver.api.controller.challenge.response
+
+import com.alloon.alloonserver.service.challenge.dto.FindChallengeFeedsDto
+import com.fasterxml.jackson.annotation.JsonFormat
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDateTime
+import java.time.LocalTime
+
+@Schema(description = "챌린지 피드 조회 응답 객체")
+data class FindChallengeFeedsResponse(
+
+    @Schema(description = "피드 id", example = "1")
+    val id: Long,
+
+    @Schema(description = "사용자 아이디", example = "photi")
+    val username: String,
+
+    @Schema(description = "피드 이미지", example = "https://url.kr/5MhHhD")
+    val imageUrl: String,
+
+    @Schema(description = "피드 인증 날짜")
+    val createdDateTime: LocalDateTime,
+
+    @Schema(description = "챌린지 인증 시간", example = "13:00")
+    @field:JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "kk:mm")
+    val proveTime: LocalTime,
+) {
+
+    companion object {
+
+        fun of(feed: FindChallengeFeedsDto): FindChallengeFeedsResponse {
+            return FindChallengeFeedsResponse(
+                feed.id,
+                feed.username,
+                feed.imageUrl,
+                feed.createdDateTime,
+                feed.proveTime,
+            )
+        }
+
+        fun of(feeds: List<FindChallengeFeedsDto>): List<FindChallengeFeedsResponse> =
+            feeds.map { of(it) }
+    }
+}

--- a/src/main/kotlin/com/alloon/alloonserver/common/constant/SortTypeConstants.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/common/constant/SortTypeConstants.kt
@@ -1,0 +1,9 @@
+package com.alloon.alloonserver.common.constant
+
+enum class SortTypeConstants(
+    val sort: String
+) {
+
+    LATEST("최신순"),
+    POPULAR("인기순")
+}

--- a/src/main/kotlin/com/alloon/alloonserver/domain/feed/custom/FeedCustomRepository.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/domain/feed/custom/FeedCustomRepository.kt
@@ -1,8 +1,19 @@
 package com.alloon.alloonserver.domain.feed.custom
 
+import com.alloon.alloonserver.common.constant.SortTypeConstants
 import com.alloon.alloonserver.domain.feed.Feed
+import com.alloon.alloonserver.service.challenge.dto.FindChallengeFeedsDto
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
+import java.time.LocalDate
 
 interface FeedCustomRepository {
 
     fun find(id: Long): Feed?
+
+    fun findAllByChallengeId(
+        challengeId: Long,
+        pageable: Pageable,
+        sort: SortTypeConstants
+    ): Slice<Pair<LocalDate, List<FindChallengeFeedsDto>>>
 }

--- a/src/main/kotlin/com/alloon/alloonserver/domain/feed/custom/FeedCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/domain/feed/custom/FeedCustomRepositoryImpl.kt
@@ -1,12 +1,23 @@
 package com.alloon.alloonserver.domain.feed.custom
 
+import com.alloon.alloonserver.common.constant.SortTypeConstants
+import com.alloon.alloonserver.common.constant.SortTypeConstants.LATEST
+import com.alloon.alloonserver.common.constant.SortTypeConstants.POPULAR
 import com.alloon.alloonserver.domain.base.ServiceStatus
 import com.alloon.alloonserver.domain.base.ServiceStatus.ACTIVE
 import com.alloon.alloonserver.domain.feed.Feed
 import com.alloon.alloonserver.domain.feed.QFeed.feed
+import com.alloon.alloonserver.service.challenge.dto.FindChallengeFeedsDto
+import com.alloon.alloonserver.service.challenge.dto.QFindChallengeFeedsDto
+import com.querydsl.core.types.Order.DESC
+import com.querydsl.core.types.OrderSpecifier
 import com.querydsl.core.types.dsl.BooleanExpression
 import com.querydsl.jpa.impl.JPAQueryFactory
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
+import org.springframework.data.domain.SliceImpl
 import org.springframework.stereotype.Repository
+import java.time.LocalDate
 
 @Repository
 class FeedCustomRepositoryImpl(
@@ -22,6 +33,50 @@ class FeedCustomRepositoryImpl(
             ).fetchFirst()
     }
 
+    override fun findAllByChallengeId(
+        challengeId: Long,
+        pageable: Pageable,
+        sort: SortTypeConstants
+    ): Slice<Pair<LocalDate, List<FindChallengeFeedsDto>>> {
+        val pageSize = pageable.pageSize
+        val content = queryFactory
+            .select(
+                QFindChallengeFeedsDto(
+                    feed.id,
+                    feed.challengeMember.user.username,
+                    feed.imageUrl,
+                    feed.createDateTime,
+                    feed.challenge.proveTime,
+                )
+            )
+            .from(feed)
+            .join(feed.challenge)
+            .join(feed.challengeMember.user)
+            .where(feed.challenge.id.eq(challengeId))
+            .orderBy(getOrderSpecifier(sort))
+            .offset(pageable.offset)
+            .limit(pageSize + 1L)
+            .fetch()
+
+        val hasNext = if (content.size > pageSize) {
+            content.removeAt(pageSize)
+            true
+        } else {
+            false
+        }
+
+        val groupedContent = content.groupBy { it.createdDateTime.toLocalDate() }.toList()
+
+        return SliceImpl(groupedContent, pageable, hasNext)
+    }
+
     private fun eqServiceStatus(serviceStatus: ServiceStatus?): BooleanExpression? =
         serviceStatus?.let { feed.serviceStatus.eq(serviceStatus) }
+
+    private fun getOrderSpecifier(sort: SortTypeConstants): OrderSpecifier<*> {
+        return when (sort) {
+            LATEST -> OrderSpecifier(DESC, feed.createDateTime)
+            POPULAR -> OrderSpecifier(DESC, feed.likeCnt.add(feed.likeCnt)) // TODO 댓글 수로 변경
+        }
+    }
 }

--- a/src/main/kotlin/com/alloon/alloonserver/service/challenge/ChallengeService.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/service/challenge/ChallengeService.kt
@@ -1,7 +1,9 @@
 package com.alloon.alloonserver.service.challenge
 
+import com.alloon.alloonserver.api.controller.challenge.response.FindChallengeFeedsByDateResponse
 import com.alloon.alloonserver.api.controller.challenge.response.FindChallengesResponse
 import com.alloon.alloonserver.common.constant.ExceptionCode.*
+import com.alloon.alloonserver.common.constant.SortTypeConstants
 import com.alloon.alloonserver.common.response.CustomException
 import com.alloon.alloonserver.domain.challenge.*
 import com.alloon.alloonserver.domain.feed.Feed
@@ -155,6 +157,17 @@ class ChallengeService(
         user.decreaseFeedCnt()
 
         // TODO 댓글, 좋아요 삭제
+    }
+
+    fun findChallengeFeeds(
+        challengeId: Long,
+        pageable: Pageable,
+        sort: SortTypeConstants,
+    ): Slice<FindChallengeFeedsByDateResponse> {
+        return feedRepository.findAllByChallengeId(challengeId, pageable, sort)
+            .map { (createdDate, feeds) ->
+                FindChallengeFeedsByDateResponse.of(createdDate, feeds)
+            }
     }
 
     private fun validateUser(userId: Long): User {

--- a/src/main/kotlin/com/alloon/alloonserver/service/challenge/dto/FindChallengeFeedsDto.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/service/challenge/dto/FindChallengeFeedsDto.kt
@@ -1,0 +1,13 @@
+package com.alloon.alloonserver.service.challenge.dto
+
+import com.querydsl.core.annotations.QueryProjection
+import java.time.LocalDateTime
+import java.time.LocalTime
+
+data class FindChallengeFeedsDto @QueryProjection constructor(
+    val id: Long,
+    val username: String,
+    val imageUrl: String,
+    val createdDateTime: LocalDateTime,
+    val proveTime: LocalTime,
+)

--- a/src/test/kotlin/com/alloon/alloonserver/api/controller/challenge/ChallengeControllerTest.kt
+++ b/src/test/kotlin/com/alloon/alloonserver/api/controller/challenge/ChallengeControllerTest.kt
@@ -2,6 +2,7 @@ package com.alloon.alloonserver.api.controller.challenge
 
 import com.alloon.alloonserver.api.controller.RestDocsSupport
 import com.alloon.alloonserver.api.controller.challenge.request.*
+import com.alloon.alloonserver.api.controller.challenge.response.FindChallengeFeedsByDateResponse
 import com.alloon.alloonserver.api.controller.challenge.response.FindChallengesResponse
 import com.alloon.alloonserver.service.challenge.ChallengeService
 import com.alloon.alloonserver.service.challenge.dto.*
@@ -290,6 +291,32 @@ class ChallengeControllerTest : RestDocsSupport() {
         resultActions.andExpect(status().isOk)
     }
 
+    @DisplayName("챌린지 피드 조회를 성공하면 200을 반환한다.")
+    @Test
+    fun givenValid_whenFindChallengeFeeds_thenReturn200() {
+        // given
+        val feeds = listOf(getFindChallengeFeedsDto())
+        val content = listOf(FindChallengeFeedsByDateResponse.of(LocalDate.now(), feeds))
+        val pageable = PageRequest.of(0, 10)
+        val hasNext = true
+
+        every { challengeService.findChallengeFeeds(any(), any(), any()) } returns SliceImpl(
+            content,
+            pageable,
+            hasNext
+        )
+
+        // when
+        val resultActions = mockMvc.perform(
+            get("/api/challenges/{challengeId}/feeds", 1)
+                .header(AUTHORIZATION, "Bearer access-token")
+                .contentType(APPLICATION_JSON)
+        )
+
+        // then
+        resultActions.andExpect(status().isOk)
+    }
+
     private fun getCreateChallengeRequest(): CreateChallengeRequest {
         return CreateChallengeRequest(
             "챌린지 이름",
@@ -374,6 +401,16 @@ class ChallengeControllerTest : RestDocsSupport() {
                 ChallengeHashtagRequest("해시태그 1"),
                 ChallengeHashtagRequest("해시태그 2"),
             )
+        )
+    }
+
+    private fun getFindChallengeFeedsDto(): FindChallengeFeedsDto {
+        return FindChallengeFeedsDto(
+            1L,
+            "tester",
+            "https://url.kr/5MhHhD",
+            LocalDateTime.now(),
+            LocalTime.of(13, 0),
         )
     }
 }

--- a/src/test/kotlin/com/alloon/alloonserver/service/challenge/ChallengeServiceTest.kt
+++ b/src/test/kotlin/com/alloon/alloonserver/service/challenge/ChallengeServiceTest.kt
@@ -1,6 +1,7 @@
 package com.alloon.alloonserver.service.challenge
 
 import com.alloon.alloonserver.common.constant.ExceptionCode.*
+import com.alloon.alloonserver.common.constant.SortTypeConstants
 import com.alloon.alloonserver.common.response.CustomException
 import com.alloon.alloonserver.domain.challenge.ChallengeMember
 import com.alloon.alloonserver.domain.challenge.ChallengeMemberRepository
@@ -511,6 +512,30 @@ class ChallengeServiceTest : AbstractMailProperties {
             .isEqualTo(FEED_NOT_FOUND)
     }
 
+    @DisplayName("챌린지 피드 조회를 하면 정렬 기준으로 정렬된 페이징 객체를 반환한다.")
+    @Test
+    fun givenValid_whenFindChallengeFeeds_thenReturn() {
+        // given
+        val challengeId = 1L
+        val sort = SortTypeConstants.LATEST
+        val dto = getFindChallengeFeedsDto()
+        val content = listOf(
+            Pair(LocalDate.of(2024, 10, 9), listOf(dto, dto, dto)),
+            Pair(LocalDate.of(2024, 10, 8), listOf(dto, dto, dto))
+        )
+        val pageable = PageRequest.of(0, 10)
+        val hasNext = true
+
+        every { feedRepository.findAllByChallengeId(any(), any(), any()) } returns
+                SliceImpl(content, pageable, hasNext)
+
+        // when
+        val result = challengeService.findChallengeFeeds(challengeId, pageable, sort)
+
+        // then
+        assertThat(result.content.size).isEqualTo(2)
+    }
+
     private fun getUser(): User {
         val contact = Contact(1L, "tester@photi.com", "000000", true)
         return User(1L, contact, "tester", "password1!", "")
@@ -601,6 +626,16 @@ class ChallengeServiceTest : AbstractMailProperties {
                 ChallengeHashtagDto("해시태그 3"),
                 ChallengeHashtagDto("해시태그 4"),
             ),
+        )
+    }
+
+    private fun getFindChallengeFeedsDto(): FindChallengeFeedsDto {
+        return FindChallengeFeedsDto(
+            1L,
+            "tester",
+            "https://url.kr/5MhHhD",
+            LocalDateTime.now(),
+            LocalTime.of(13, 0),
         )
     }
 }


### PR DESCRIPTION
## 📋 이슈 번호
- close #128
  </br>

## 🛠 구현 사항
- 페이징 처리 (최신순, 인기순 정렬)
  - 최신순 - 피드 인증 날짜 최신 순
  - 인기순 - 반응 수(하트 수 + 댓글 수) 많은 순
- 피드 인증 날짜, 오늘 인증한 파티원 수, 피드 목록(사용자 아이디, 피드 이미지, 피드 인증 날짜 시간, 챌린지 인증 시간) 조회
- `groupBy` 메소드를 통해 Map(key-날짜, value-피드 조회 응답 객체)으로 반환하여 날짜별로 그룹화
  </br>

## 📚 기타
- 피드 댓글 구현 후 하트 수 + 댓글 수로 정렬하는 기준 추가
  </br>