### PR TITLE
[feat] 피드 댓글 삭제 API

### DIFF
--- a/src/main/kotlin/com/alloon/alloonserver/api/controller/challenge/ChallengeController.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/api/controller/challenge/ChallengeController.kt
@@ -257,4 +257,22 @@ class ChallengeController(
         return ResponseEntity.status(CREATED)
             .body(StringSuccessResponse("챌린지 피드 댓글 등록이 완료되었습니다."))
     }
+
+    @DeleteMapping("/{challengeId}/feeds/{feedId}/comments")
+    @Operation(summary = "챌린지 피드 댓글 삭제", security = [SecurityRequirement(name = ACCESS_TOKEN_KEY)])
+    @ApiResponse(responseCode = "200")
+    @ApiErrorResponses([TOKEN_UNAUTHENTICATED, TOKEN_UNAUTHORIZED, CHALLENGE_NOT_FOUND, CHALLENGE_MEMBER_NOT_FOUND, FEED_NOT_FOUND, FEED_COMMENT_NOT_FOUND])
+    fun deleteChallengeFeedComment(
+        principal: Principal,
+        @PathVariable @Parameter(description = "챌린지 id", example = "1") challengeId: Long,
+        @PathVariable @Parameter(description = "피드 id", example = "1") feedId: Long,
+    ): ResponseEntity<StringSuccessResponse> {
+        challengeService.deleteChallengeFeedComment(
+            UserUtility.getUserId(principal),
+            challengeId,
+            feedId,
+        )
+
+        return ResponseEntity.ok(StringSuccessResponse("챌린지 피드 댓글 삭제가 완료되었습니다."))
+    }
 }

--- a/src/main/kotlin/com/alloon/alloonserver/common/constant/ExceptionCode.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/common/constant/ExceptionCode.kt
@@ -87,6 +87,7 @@ enum class ExceptionCode(
     CHALLENGE_NOT_FOUND(NOT_FOUND, "존재하지 않는 챌린지입니다."),
     CHALLENGE_MEMBER_NOT_FOUND(NOT_FOUND, "존재하지 않는 챌린지 파티원입니다."),
     FEED_NOT_FOUND(NOT_FOUND, "존재하지 않는 피드입니다."),
+    FEED_COMMENT_NOT_FOUND(NOT_FOUND, "존재하지 않는 피드 댓글입니다."),
 
     /**
      * 405 Method Not Allowed

--- a/src/main/kotlin/com/alloon/alloonserver/domain/feed/FeedCommentRepository.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/domain/feed/FeedCommentRepository.kt
@@ -3,4 +3,6 @@ package com.alloon.alloonserver.domain.feed
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface FeedCommentRepository : JpaRepository<FeedComment, Long> {
+
+    fun findByChallengeMemberIdAndFeedId(challengeId: Long?, feedId: Long): FeedComment?
 }

--- a/src/main/kotlin/com/alloon/alloonserver/domain/feed/FeedCommentRepository.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/domain/feed/FeedCommentRepository.kt
@@ -4,5 +4,5 @@ import org.springframework.data.jpa.repository.JpaRepository
 
 interface FeedCommentRepository : JpaRepository<FeedComment, Long> {
 
-    fun findByChallengeMemberIdAndFeedId(challengeId: Long?, feedId: Long): FeedComment?
+    fun findByChallengeMemberIdAndFeedId(challengeMemberId: Long?, feedId: Long): FeedComment?
 }

--- a/src/main/kotlin/com/alloon/alloonserver/domain/feed/custom/FeedCustomRepository.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/domain/feed/custom/FeedCustomRepository.kt
@@ -11,6 +11,8 @@ interface FeedCustomRepository {
 
     fun find(id: Long): Feed?
 
+    fun findByFeedId(id: Long): Feed?
+
     fun findAllByChallengeId(
         challengeId: Long,
         pageable: Pageable,

--- a/src/main/kotlin/com/alloon/alloonserver/domain/feed/custom/FeedCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/domain/feed/custom/FeedCustomRepositoryImpl.kt
@@ -33,6 +33,14 @@ class FeedCustomRepositoryImpl(
             ).fetchFirst()
     }
 
+    override fun findByFeedId(id: Long): Feed? {
+        return queryFactory
+            .selectFrom(feed)
+            .join(feed.challengeMember).fetchJoin()
+            .where(feed.id.eq(id))
+            .fetchFirst()
+    }
+
     override fun findAllByChallengeId(
         challengeId: Long,
         pageable: Pageable,

--- a/src/main/kotlin/com/alloon/alloonserver/service/challenge/ChallengeService.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/service/challenge/ChallengeService.kt
@@ -15,6 +15,7 @@ import com.alloon.alloonserver.service.challenge.dto.*
 import com.alloon.alloonserver.service.s3.FolderType.CHALLENGES
 import com.alloon.alloonserver.service.s3.FolderType.FEEDS
 import com.alloon.alloonserver.service.s3.S3Service
+import io.sentry.MeasurementUnit.Custom
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Slice
 import org.springframework.stereotype.Service
@@ -181,10 +182,22 @@ class ChallengeService(
     ) {
         validateChallenge(challengeId)
         val challengeMember = validateChallengeMember(userId, challengeId)
-        val feed = feedRepository.findById(feedId).orElseThrow { CustomException(FEED_NOT_FOUND) }
+        val feed = validateChallengeFeed(feedId)
         val feedComment = dto.toEntity(challengeMember, feed)
 
         feedCommentRepository.save(feedComment)
+    }
+
+    @Transactional
+    fun deleteChallengeFeedComment(userId: Long, challengeId: Long, feedId: Long) {
+        validateChallenge(challengeId)
+        validateChallengeFeed(feedId)
+        val challengeMemberId = validateChallengeMember(userId, challengeId).id
+        val feedComment =
+            feedCommentRepository.findByChallengeMemberIdAndFeedId(challengeMemberId, feedId)
+                ?: throw CustomException(FEED_COMMENT_NOT_FOUND)
+
+        feedCommentRepository.delete(feedComment)
     }
 
     private fun validateUser(userId: Long): User {
@@ -219,5 +232,9 @@ class ChallengeService(
         if (isFeedCreated) {
             throw CustomException(EXISTING_FEED)
         }
+    }
+
+    private fun validateChallengeFeed(feedId: Long): Feed {
+        return feedRepository.findByFeedId(feedId) ?: throw CustomException(FEED_NOT_FOUND)
     }
 }

--- a/src/test/kotlin/com/alloon/alloonserver/api/controller/challenge/ChallengeControllerTest.kt
+++ b/src/test/kotlin/com/alloon/alloonserver/api/controller/challenge/ChallengeControllerTest.kt
@@ -338,6 +338,24 @@ class ChallengeControllerTest : RestDocsSupport() {
         resultActions.andExpect(status().isCreated)
     }
 
+    @DisplayName("챌린지 피드 댓글 삭제를 성공하면 200을 반환한다.")
+    @Test
+    fun givenValid_whenDeleteChallengeFeedComment_thenReturn200() {
+        // given
+        every { challengeService.deleteChallengeFeedComment(any(), any(), any()) } just Runs
+
+        // when
+        val resultActions = mockMvc.perform(
+            delete("/api/challenges/{challengeId}/feeds/{feedId}/comments", 1, 1)
+                .header(AUTHORIZATION, "Bearer access-token")
+                .principal(mockPrincipal)
+                .contentType(APPLICATION_JSON)
+        )
+
+        // then
+        resultActions.andExpect(status().isOk)
+    }
+
     private fun getCreateChallengeRequest(): CreateChallengeRequest {
         return CreateChallengeRequest(
             "챌린지 이름",

--- a/src/test/kotlin/com/alloon/alloonserver/service/challenge/ChallengeServiceTest.kt
+++ b/src/test/kotlin/com/alloon/alloonserver/service/challenge/ChallengeServiceTest.kt
@@ -7,6 +7,7 @@ import com.alloon.alloonserver.domain.challenge.ChallengeMember
 import com.alloon.alloonserver.domain.challenge.ChallengeMemberRepository
 import com.alloon.alloonserver.domain.challenge.ChallengeRepository
 import com.alloon.alloonserver.domain.feed.Feed
+import com.alloon.alloonserver.domain.feed.FeedComment
 import com.alloon.alloonserver.domain.feed.FeedCommentRepository
 import com.alloon.alloonserver.domain.feed.FeedRepository
 import com.alloon.alloonserver.domain.user.Contact
@@ -645,6 +646,136 @@ class ChallengeServiceTest : AbstractMailProperties {
             .isInstanceOf(CustomException::class.java)
             .extracting("exceptionCode")
             .isEqualTo(FEED_NOT_FOUND)
+    }
+
+    @DisplayName("챌린지 피드 댓글 삭제를 하면 해당 챌린지 파티원의 댓글이 삭제된다.")
+    @Test
+    fun givenValid_whenDeleteChallengeFeedComment_thenReturn() {
+        // given
+        val user = getUser()
+        val imageUrl = "https://url.kr/5MhHhD"
+        val challenge = getCreateChallengeDto().toEntity(imageUrl)
+        val challengeMember = ChallengeMember(user = user, challenge = challenge)
+        val feed =
+            Feed(challengeMember = challengeMember, challenge = challenge, imageUrl = imageUrl)
+        val feedComment = FeedComment(1L, challengeMember, feed, "피드 댓글")
+        val userId = 1L
+        val challengeId = 1L
+        val feedId = 1L
+
+        every { challengeRepository.findInfoById(any()) } returns challenge
+        every { feedRepository.findByFeedId(any()) } returns feed
+        every {
+            challengeMemberRepository.findByUserIdAndChallengeId(userId, challengeId)
+        } returns challengeMember
+        every { feedCommentRepository.findByChallengeMemberIdAndFeedId(any(), any()) } returns feedComment
+        every { feedCommentRepository.delete(any()) } just Runs
+
+        // when
+        challengeService.deleteChallengeFeedComment(userId, challengeId, feedId)
+
+        // then
+        verify { feedCommentRepository.delete(feedComment) }
+    }
+
+    @DisplayName("등록되지 않은 챌린지의 피드 댓글 삭제를 하면 예외가 발생한다.")
+    @Test
+    fun givenNotFoundChallenge_whenDeleteChallengeFeedComment_thenThrow() {
+        // given
+        val userId = 1L
+        val challengeId = 1L
+        val feedId = 1L
+
+        every { challengeRepository.findInfoById(any()) } returns null
+
+        // when & then
+        assertThatThrownBy {
+            challengeService.deleteChallengeFeedComment(userId, challengeId, feedId)
+        }
+            .isInstanceOf(CustomException::class.java)
+            .extracting("exceptionCode")
+            .isEqualTo(CHALLENGE_NOT_FOUND)
+    }
+
+    @DisplayName("등록되지 않은 피드의 댓글 삭제를 하면 예외가 발생한다.")
+    @Test
+    fun givenNotFoundFeed_whenDeleteChallengeFeedComment_thenThrow() {
+        // given
+        val imageUrl = "https://url.kr/5MhHhD"
+        val challenge = getCreateChallengeDto().toEntity(imageUrl)
+        val userId = 1L
+        val challengeId = 1L
+        val feedId = 1L
+
+        every { challengeRepository.findInfoById(any()) } returns challenge
+        every { feedRepository.findByFeedId(any()) } returns null
+
+        // when & then
+        assertThatThrownBy {
+            challengeService.deleteChallengeFeedComment(userId, challengeId, feedId)
+        }
+            .isInstanceOf(CustomException::class.java)
+            .extracting("exceptionCode")
+            .isEqualTo(FEED_NOT_FOUND)
+    }
+
+    @DisplayName("등록되지 않은 챌린지 파티원이 댓글 삭제를 하면 예외가 발생한다.")
+    @Test
+    fun givenNotFoundChallengeMember_whenDeleteChallengeFeedComment_thenThrow() {
+        // given
+        val user = getUser()
+        val imageUrl = "https://url.kr/5MhHhD"
+        val challenge = getCreateChallengeDto().toEntity(imageUrl)
+        val challengeMember = ChallengeMember(user = user, challenge = challenge)
+        val feed =
+            Feed(challengeMember = challengeMember, challenge = challenge, imageUrl = imageUrl)
+        val userId = 1L
+        val challengeId = 1L
+        val feedId = 1L
+
+        every { challengeRepository.findInfoById(any()) } returns challenge
+        every { feedRepository.findByFeedId(any()) } returns feed
+        every {
+            challengeMemberRepository.findByUserIdAndChallengeId(userId, challengeId)
+        } returns null
+
+        // when & then
+        assertThatThrownBy {
+            challengeService.deleteChallengeFeedComment(userId, challengeId, feedId)
+        }
+            .isInstanceOf(CustomException::class.java)
+            .extracting("exceptionCode")
+            .isEqualTo(CHALLENGE_MEMBER_NOT_FOUND)
+    }
+
+    @DisplayName("등록되지 않은 댓글 삭제를 하면 예외가 발생한다.")
+    @Test
+    fun givenNotFoundFeedComment_whenDeleteChallengeFeedComment_thenThrow() {
+        // given
+        val user = getUser()
+        val imageUrl = "https://url.kr/5MhHhD"
+        val challenge = getCreateChallengeDto().toEntity(imageUrl)
+        val challengeMember = ChallengeMember(user = user, challenge = challenge)
+        val feed =
+            Feed(challengeMember = challengeMember, challenge = challenge, imageUrl = imageUrl)
+        val userId = 1L
+        val challengeId = 1L
+        val feedId = 1L
+
+        every { challengeRepository.findInfoById(any()) } returns challenge
+        every { feedRepository.findByFeedId(any()) } returns feed
+        every {
+            challengeMemberRepository.findByUserIdAndChallengeId(userId, challengeId)
+        } returns challengeMember
+        every { feedCommentRepository.findByChallengeMemberIdAndFeedId(any(), any()) } returns null
+
+        // when & then
+        assertThatThrownBy {
+            challengeService.deleteChallengeFeedComment(userId, challengeId, feedId)
+        }
+            .isInstanceOf(CustomException::class.java)
+            .extracting("exceptionCode")
+            .isEqualTo(FEED_COMMENT_NOT_FOUND)
     }
 
     private fun getUser(): User {

--- a/src/test/kotlin/com/alloon/alloonserver/service/challenge/ChallengeServiceTest.kt
+++ b/src/test/kotlin/com/alloon/alloonserver/service/challenge/ChallengeServiceTest.kt
@@ -562,7 +562,7 @@ class ChallengeServiceTest : AbstractMailProperties {
         every {
             challengeMemberRepository.findByUserIdAndChallengeId(userId, challengeId)
         } returns challengeMember
-        every { feedRepository.findById(any()) } returns Optional.of(feed)
+        every { feedRepository.findByFeedId(any()) } returns feed
         every { feedCommentRepository.save(any()) } returns feedComment
 
         // when
@@ -637,7 +637,7 @@ class ChallengeServiceTest : AbstractMailProperties {
         every {
             challengeMemberRepository.findByUserIdAndChallengeId(userId, challengeId)
         } returns challengeMember
-        every { feedRepository.findById(any()) } returns Optional.empty()
+        every { feedRepository.findByFeedId(any()) } returns null
 
         // when & then
         assertThatThrownBy {


### PR DESCRIPTION
## 📋 이슈 번호
- close #132 
  </br>

## 🛠 구현 사항
- 피드 조회 메소드 select 쿼리 호출 줄이기 위해 fetchjoin 사용
- 피드 댓글은 댓글 작성자만 삭제 가능
  </br>

## 📚 기타
- 
  </br>