### PR TITLE
[feat] feed 엔티티 댓글 수 컬럼 추가

### DIFF
--- a/docker/init.sql
+++ b/docker/init.sql
@@ -129,6 +129,7 @@ CREATE TABLE feed
 (
     feed_id                     BIGSERIAL PRIMARY KEY,
     like_cnt                    INT                       NOT NULL,
+    comment_cnt                 INT                       NOT NULL,
     image_url                   VARCHAR(500)              NOT NULL,
     create_date_time            TIMESTAMP(6)              NOT NULL,
     update_date_time            TIMESTAMP(6)              NOT NULL,

--- a/src/main/kotlin/com/alloon/alloonserver/domain/feed/Feed.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/domain/feed/Feed.kt
@@ -26,5 +26,16 @@ class Feed(
 
     @Column(nullable = false)
     val likeCnt: Int = 0,
+
+    @Column(nullable = false)
+    var commentCnt: Int = 0,
 ) : BasePermanentEntity() {
+
+    fun updateCommentCnt() {
+        commentCnt += 1
+    }
+
+    fun decreaseCommentCnt() {
+        commentCnt -= 1
+    }
 }

--- a/src/main/kotlin/com/alloon/alloonserver/domain/feed/Feed.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/domain/feed/Feed.kt
@@ -36,6 +36,8 @@ class Feed(
     }
 
     fun decreaseCommentCnt() {
-        commentCnt -= 1
+        if (commentCnt > 0) {
+            commentCnt -= 1
+        }
     }
 }

--- a/src/main/kotlin/com/alloon/alloonserver/domain/feed/custom/FeedCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/domain/feed/custom/FeedCustomRepositoryImpl.kt
@@ -84,7 +84,7 @@ class FeedCustomRepositoryImpl(
     private fun getOrderSpecifier(sort: SortTypeConstants): OrderSpecifier<*> {
         return when (sort) {
             LATEST -> OrderSpecifier(DESC, feed.createDateTime)
-            POPULAR -> OrderSpecifier(DESC, feed.likeCnt.add(feed.likeCnt)) // TODO 댓글 수로 변경
+            POPULAR -> OrderSpecifier(DESC, feed.likeCnt.add(feed.commentCnt))
         }
     }
 }

--- a/src/main/kotlin/com/alloon/alloonserver/service/challenge/ChallengeService.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/service/challenge/ChallengeService.kt
@@ -15,7 +15,6 @@ import com.alloon.alloonserver.service.challenge.dto.*
 import com.alloon.alloonserver.service.s3.FolderType.CHALLENGES
 import com.alloon.alloonserver.service.s3.FolderType.FEEDS
 import com.alloon.alloonserver.service.s3.S3Service
-import io.sentry.MeasurementUnit.Custom
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Slice
 import org.springframework.stereotype.Service
@@ -186,18 +185,20 @@ class ChallengeService(
         val feedComment = dto.toEntity(challengeMember, feed)
 
         feedCommentRepository.save(feedComment)
+        feed.updateCommentCnt()
     }
 
     @Transactional
     fun deleteChallengeFeedComment(userId: Long, challengeId: Long, feedId: Long) {
         validateChallenge(challengeId)
-        validateChallengeFeed(feedId)
+        val feed = validateChallengeFeed(feedId)
         val challengeMemberId = validateChallengeMember(userId, challengeId).id
         val feedComment =
             feedCommentRepository.findByChallengeMemberIdAndFeedId(challengeMemberId, feedId)
                 ?: throw CustomException(FEED_COMMENT_NOT_FOUND)
 
         feedCommentRepository.delete(feedComment)
+        feed.decreaseCommentCnt()
     }
 
     private fun validateUser(userId: Long): User {

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -129,6 +129,7 @@ CREATE TABLE feed
 (
     feed_id                     BIGSERIAL PRIMARY KEY,
     like_cnt                    INT                       NOT NULL,
+    comment_cnt                 INT                       NOT NULL,
     image_url                   VARCHAR(500)              NOT NULL,
     create_date_time            TIMESTAMP(6)              NOT NULL,
     update_date_time            TIMESTAMP(6)              NOT NULL,

--- a/src/test/kotlin/com/alloon/alloonserver/domain/feed/FeedTest.kt
+++ b/src/test/kotlin/com/alloon/alloonserver/domain/feed/FeedTest.kt
@@ -1,0 +1,97 @@
+package com.alloon.alloonserver.domain.feed
+
+import com.alloon.alloonserver.domain.challenge.ChallengeMember
+import com.alloon.alloonserver.domain.user.Contact
+import com.alloon.alloonserver.domain.user.User
+import com.alloon.alloonserver.service.challenge.dto.ChallengeHashtagDto
+import com.alloon.alloonserver.service.challenge.dto.ChallengeRuleDto
+import com.alloon.alloonserver.service.challenge.dto.CreateChallengeDto
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+import java.time.LocalTime
+
+class FeedTest {
+
+    @DisplayName("피드 댓글 수가 증가한다.")
+    @Test
+    fun givenValid_whenUpdateCommentCnt_thenReturn() {
+        // given
+        val imageUrl = "https://url.kr/5MhHhD"
+        val challenge = getCreateChallengeDto().toEntity(imageUrl)
+        val challengeMember = ChallengeMember(1L, getUser(getContact()), challenge)
+        val feed = Feed(1L, challengeMember, challenge, imageUrl, 10, 5)
+
+        // when
+        feed.updateCommentCnt()
+
+        // then
+        assertThat(feed.commentCnt).isEqualTo(6)
+    }
+
+    @DisplayName("피드 댓글 수가 0보다 크면 피드 댓글 수가 감소한다.")
+    @Test
+    fun givenCommentCntGreaterThanZero_whenDecreaseCommentCnt_thenReturn() {
+        // given
+        val imageUrl = "https://url.kr/5MhHhD"
+        val challenge = getCreateChallengeDto().toEntity(imageUrl)
+        val challengeMember = ChallengeMember(1L, getUser(getContact()), challenge)
+        val feed = Feed(1L, challengeMember, challenge, imageUrl, 10, 5)
+
+        // when
+        feed.decreaseCommentCnt()
+
+        // then
+        assertThat(feed.commentCnt).isEqualTo(4)
+    }
+
+    @DisplayName("피드 댓글 수가 0이면 피드 댓글 수가 감소하지 않는다.")
+    @Test
+    fun givenCommentCntZero_whenDecreaseCommentCnt_thenReturn() {
+        // given
+        val imageUrl = "https://url.kr/5MhHhD"
+        val challenge = getCreateChallengeDto().toEntity(imageUrl)
+        val challengeMember = ChallengeMember(1L, getUser(getContact()), challenge)
+        val feed = Feed(1L, challengeMember, challenge, imageUrl, 10, 0)
+
+        // when
+        feed.decreaseCommentCnt()
+
+        // then
+        assertThat(feed.commentCnt).isEqualTo(0)
+    }
+
+    private fun getUser(contact: Contact): User {
+        return User(
+            contact = contact,
+            username = "tester",
+            password = "password1!",
+            imageUrl = "",
+            feedCnt = 4
+        )
+    }
+
+    private fun getContact(): Contact {
+        return Contact(email = "tester@photi.com", verificationCode = "000000")
+    }
+
+    private fun getCreateChallengeDto(): CreateChallengeDto {
+        return CreateChallengeDto(
+            "챌린지 이름",
+            true,
+            "챌린지 목표입니다.",
+            LocalTime.of(13, 0),
+            LocalDate.of(2024, 12, 1),
+            listOf(
+                ChallengeRuleDto("챌린지 인증 룰1"),
+                ChallengeRuleDto("챌린지 인증 룰2"),
+                ChallengeRuleDto("챌린지 인증 룰3"),
+            ),
+            listOf(
+                ChallengeHashtagDto("해시태그 1"),
+                ChallengeHashtagDto("해시태그 2"),
+            )
+        )
+    }
+}

--- a/src/test/resources/init.sql
+++ b/src/test/resources/init.sql
@@ -110,6 +110,7 @@ CREATE TABLE feed
 (
     feed_id                     BIGSERIAL PRIMARY KEY,
     like_cnt                    INT                       NOT NULL,
+    comment_cnt                 INT                       NOT NULL,
     image_url                   VARCHAR(500)              NOT NULL,
     create_date_time            TIMESTAMP(6)              NOT NULL,
     update_date_time            TIMESTAMP(6)              NOT NULL,


### PR DESCRIPTION
## 📋 이슈 번호
- close #135 
  </br>

## 🛠 구현 사항
- 피드 댓글 수 컬럼 추가, 스키마 변경
- 피드 댓글 수 증가, 감소 메소드(0보다 클 때만 감소) 구현
- 피드 조회 API - 인기순 정렬 기준 (하트 수 + 댓글 수)로 변경
  </br>

## 📚 기타
- 
  </br>