### PR TITLE
[feat] 피드 삭제 API - 피드 댓글 삭제 기능 추가

### DIFF
--- a/src/main/kotlin/com/alloon/alloonserver/domain/feed/FeedCommentRepository.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/domain/feed/FeedCommentRepository.kt
@@ -5,4 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository
 interface FeedCommentRepository : JpaRepository<FeedComment, Long> {
 
     fun findByChallengeMemberIdAndFeedId(challengeMemberId: Long?, feedId: Long): FeedComment?
+
+    fun findAllByFeedId(feedId: Long): List<FeedComment>
 }

--- a/src/main/kotlin/com/alloon/alloonserver/service/challenge/ChallengeService.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/service/challenge/ChallengeService.kt
@@ -153,12 +153,12 @@ class ChallengeService(
         val challengeMemberId = validateChallengeMember(userId, challengeId).id
         val feed = feedRepository.findByIdAndChallengeMemberId(feedId, challengeMemberId)
             ?: throw CustomException(FEED_NOT_FOUND)
+        val feedComments = feedCommentRepository.findAllByFeedId(feedId)
 
+        feedCommentRepository.deleteAllInBatch(feedComments)
         feedRepository.delete(feed)
         s3Service.deleteImage(feed.imageUrl, FEEDS, challengeId)
         user.decreaseFeedCnt()
-
-        // TODO 댓글, 좋아요 삭제
     }
 
     fun findChallengeFeeds(

--- a/src/test/kotlin/com/alloon/alloonserver/service/challenge/ChallengeServiceTest.kt
+++ b/src/test/kotlin/com/alloon/alloonserver/service/challenge/ChallengeServiceTest.kt
@@ -33,7 +33,6 @@ import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
-import java.util.*
 
 @Transactional
 @ActiveProfiles("test")
@@ -402,7 +401,7 @@ class ChallengeServiceTest : AbstractMailProperties {
             .isEqualTo(EXISTING_FEED)
     }
 
-    @DisplayName("챌린지 피드 삭제를 하면 연관된 피드, 댓글, 좋아요가 모두 삭제되고, 사용자의 피드 인증 횟수가 감소한다.")
+    @DisplayName("챌린지 피드 삭제를 하면 연관된 피드, 댓글이 모두 삭제되고, 사용자의 피드 인증 횟수가 감소한다.")
     @Test
     fun givenValid_whenDeleteChallengeFeed_thenDeleteFeedAndCommentsAndLike() {
         // given
@@ -414,6 +413,10 @@ class ChallengeServiceTest : AbstractMailProperties {
         val challenge = getCreateChallengeDto().toEntity(imageUrl)
         val challengeMember = ChallengeMember(user = user, challenge = challenge)
         val feed = Feed(1L, challengeMember, challenge, imageUrl, 1)
+        val feedComments = listOf(
+            FeedComment(1L, challengeMember, feed, "피드 댓글"),
+            FeedComment(2L, challengeMember, feed, "피드 댓글")
+        )
 
         every { userRepository.find(any()) } returns user
         every { challengeRepository.findInfoById(any()) } returns challenge
@@ -421,6 +424,8 @@ class ChallengeServiceTest : AbstractMailProperties {
             challengeMemberRepository.findByUserIdAndChallengeId(any(), any())
         } returns challengeMember
         every { feedRepository.findByIdAndChallengeMemberId(any(), any()) } returns feed
+        every { feedCommentRepository.findAllByFeedId(any()) } returns feedComments
+        every { feedCommentRepository.deleteAllInBatch(any()) } just Runs
         every { feedRepository.delete(any()) } just Runs
         every { s3Service.deleteImage(any(), any(), any()) } just Runs
 
@@ -428,6 +433,7 @@ class ChallengeServiceTest : AbstractMailProperties {
         challengeService.deleteChallengeFeed(userId, challengeId, feedId)
 
         // then
+        verify { feedCommentRepository.deleteAllInBatch(feedComments) }
         verify { feedRepository.delete(feed) }
         verify { s3Service.deleteImage(feed.imageUrl, FEEDS, challengeId) }
         assertThat(user.feedCnt).isEqualTo(0)
@@ -668,7 +674,12 @@ class ChallengeServiceTest : AbstractMailProperties {
         every {
             challengeMemberRepository.findByUserIdAndChallengeId(userId, challengeId)
         } returns challengeMember
-        every { feedCommentRepository.findByChallengeMemberIdAndFeedId(any(), any()) } returns feedComment
+        every {
+            feedCommentRepository.findByChallengeMemberIdAndFeedId(
+                any(),
+                any()
+            )
+        } returns feedComment
         every { feedCommentRepository.delete(any()) } just Runs
 
         // when


### PR DESCRIPTION
## 📋 이슈 번호
- close #138 
  </br>

## 🛠 구현 사항
- 피드 삭제 시 연관된 피드 댓글도 모두 삭제하는 기능 구현
  </br>

## 📚 기타
- 
  </br>