### PR TITLE
[fix] 피드 댓글 삭제 API 오류 수정

### DIFF
--- a/src/main/kotlin/com/alloon/alloonserver/api/controller/challenge/ChallengeController.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/api/controller/challenge/ChallengeController.kt
@@ -258,7 +258,7 @@ class ChallengeController(
             .body(StringSuccessResponse("챌린지 피드 댓글 등록이 완료되었습니다."))
     }
 
-    @DeleteMapping("/{challengeId}/feeds/{feedId}/comments")
+    @DeleteMapping("/{challengeId}/feeds/{feedId}/comments/{commentId}")
     @Operation(summary = "챌린지 피드 댓글 삭제", security = [SecurityRequirement(name = ACCESS_TOKEN_KEY)])
     @ApiResponse(responseCode = "200")
     @ApiErrorResponses([TOKEN_UNAUTHENTICATED, TOKEN_UNAUTHORIZED, CHALLENGE_NOT_FOUND, CHALLENGE_MEMBER_NOT_FOUND, FEED_NOT_FOUND, FEED_COMMENT_NOT_FOUND])
@@ -266,11 +266,13 @@ class ChallengeController(
         principal: Principal,
         @PathVariable @Parameter(description = "챌린지 id", example = "1") challengeId: Long,
         @PathVariable @Parameter(description = "피드 id", example = "1") feedId: Long,
+        @PathVariable @Parameter(description = "댓글 id", example = "1") commentId: Long,
     ): ResponseEntity<StringSuccessResponse> {
         challengeService.deleteChallengeFeedComment(
             UserUtility.getUserId(principal),
             challengeId,
             feedId,
+            commentId,
         )
 
         return ResponseEntity.ok(StringSuccessResponse("챌린지 피드 댓글 삭제가 완료되었습니다."))

--- a/src/main/kotlin/com/alloon/alloonserver/domain/feed/FeedCommentRepository.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/domain/feed/FeedCommentRepository.kt
@@ -1,10 +1,9 @@
 package com.alloon.alloonserver.domain.feed
 
+import com.alloon.alloonserver.domain.feed.custom.FeedCommentCustomRepository
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface FeedCommentRepository : JpaRepository<FeedComment, Long> {
-
-    fun findByChallengeMemberIdAndFeedId(challengeMemberId: Long?, feedId: Long): FeedComment?
+interface FeedCommentRepository : JpaRepository<FeedComment, Long>, FeedCommentCustomRepository {
 
     fun findAllByFeedId(feedId: Long): List<FeedComment>
 }

--- a/src/main/kotlin/com/alloon/alloonserver/domain/feed/custom/FeedCommentCustomRepository.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/domain/feed/custom/FeedCommentCustomRepository.kt
@@ -1,0 +1,8 @@
+package com.alloon.alloonserver.domain.feed.custom
+
+import com.alloon.alloonserver.domain.feed.FeedComment
+
+interface FeedCommentCustomRepository {
+
+    fun findByCommentId(commentId: Long): FeedComment?
+}

--- a/src/main/kotlin/com/alloon/alloonserver/domain/feed/custom/FeedCommentCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/domain/feed/custom/FeedCommentCustomRepositoryImpl.kt
@@ -1,0 +1,21 @@
+package com.alloon.alloonserver.domain.feed.custom
+
+import com.alloon.alloonserver.domain.feed.FeedComment
+import com.alloon.alloonserver.domain.feed.QFeedComment.feedComment
+import com.querydsl.jpa.impl.JPAQueryFactory
+import org.springframework.stereotype.Repository
+
+@Repository
+class FeedCommentCustomRepositoryImpl(
+    private val queryFactory: JPAQueryFactory
+) : FeedCommentCustomRepository {
+
+    override fun findByCommentId(commentId: Long): FeedComment? {
+        return queryFactory
+            .selectFrom(feedComment)
+            .join(feedComment.feed).fetchJoin()
+            .join(feedComment.challengeMember).fetchJoin()
+            .where(feedComment.id.eq(commentId))
+            .fetchFirst()
+    }
+}

--- a/src/main/kotlin/com/alloon/alloonserver/service/challenge/ChallengeService.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/service/challenge/ChallengeService.kt
@@ -189,13 +189,12 @@ class ChallengeService(
     }
 
     @Transactional
-    fun deleteChallengeFeedComment(userId: Long, challengeId: Long, feedId: Long) {
+    fun deleteChallengeFeedComment(userId: Long, challengeId: Long, feedId: Long, commentId: Long) {
         validateChallenge(challengeId)
         val feed = validateChallengeFeed(feedId)
-        val challengeMemberId = validateChallengeMember(userId, challengeId).id
-        val feedComment =
-            feedCommentRepository.findByChallengeMemberIdAndFeedId(challengeMemberId, feedId)
-                ?: throw CustomException(FEED_COMMENT_NOT_FOUND)
+        validateChallengeMember(userId, challengeId)
+        val feedComment = feedCommentRepository.findByCommentId(commentId)
+            ?: throw CustomException(FEED_COMMENT_NOT_FOUND)
 
         feedCommentRepository.delete(feedComment)
         feed.decreaseCommentCnt()

--- a/src/test/kotlin/com/alloon/alloonserver/api/controller/challenge/ChallengeControllerTest.kt
+++ b/src/test/kotlin/com/alloon/alloonserver/api/controller/challenge/ChallengeControllerTest.kt
@@ -342,11 +342,11 @@ class ChallengeControllerTest : RestDocsSupport() {
     @Test
     fun givenValid_whenDeleteChallengeFeedComment_thenReturn200() {
         // given
-        every { challengeService.deleteChallengeFeedComment(any(), any(), any()) } just Runs
+        every { challengeService.deleteChallengeFeedComment(any(), any(), any(), any()) } just Runs
 
         // when
         val resultActions = mockMvc.perform(
-            delete("/api/challenges/{challengeId}/feeds/{feedId}/comments", 1, 1)
+            delete("/api/challenges/{challengeId}/feeds/{feedId}/comments/{commentId}", 1, 1, 1)
                 .header(AUTHORIZATION, "Bearer access-token")
                 .principal(mockPrincipal)
                 .contentType(APPLICATION_JSON)

--- a/src/test/kotlin/com/alloon/alloonserver/service/challenge/ChallengeServiceTest.kt
+++ b/src/test/kotlin/com/alloon/alloonserver/service/challenge/ChallengeServiceTest.kt
@@ -668,22 +668,18 @@ class ChallengeServiceTest : AbstractMailProperties {
         val userId = 1L
         val challengeId = 1L
         val feedId = 1L
+        val commentId = 1L
 
         every { challengeRepository.findInfoById(any()) } returns challenge
         every { feedRepository.findByFeedId(any()) } returns feed
         every {
             challengeMemberRepository.findByUserIdAndChallengeId(userId, challengeId)
         } returns challengeMember
-        every {
-            feedCommentRepository.findByChallengeMemberIdAndFeedId(
-                any(),
-                any()
-            )
-        } returns feedComment
+        every { feedCommentRepository.findByCommentId(any()) } returns feedComment
         every { feedCommentRepository.delete(any()) } just Runs
 
         // when
-        challengeService.deleteChallengeFeedComment(userId, challengeId, feedId)
+        challengeService.deleteChallengeFeedComment(userId, challengeId, feedId, commentId)
 
         // then
         verify { feedCommentRepository.delete(feedComment) }
@@ -696,12 +692,13 @@ class ChallengeServiceTest : AbstractMailProperties {
         val userId = 1L
         val challengeId = 1L
         val feedId = 1L
+        val commentId = 1L
 
         every { challengeRepository.findInfoById(any()) } returns null
 
         // when & then
         assertThatThrownBy {
-            challengeService.deleteChallengeFeedComment(userId, challengeId, feedId)
+            challengeService.deleteChallengeFeedComment(userId, challengeId, feedId, commentId)
         }
             .isInstanceOf(CustomException::class.java)
             .extracting("exceptionCode")
@@ -717,13 +714,14 @@ class ChallengeServiceTest : AbstractMailProperties {
         val userId = 1L
         val challengeId = 1L
         val feedId = 1L
+        val commentId = 1L
 
         every { challengeRepository.findInfoById(any()) } returns challenge
         every { feedRepository.findByFeedId(any()) } returns null
 
         // when & then
         assertThatThrownBy {
-            challengeService.deleteChallengeFeedComment(userId, challengeId, feedId)
+            challengeService.deleteChallengeFeedComment(userId, challengeId, feedId, commentId)
         }
             .isInstanceOf(CustomException::class.java)
             .extracting("exceptionCode")
@@ -743,6 +741,7 @@ class ChallengeServiceTest : AbstractMailProperties {
         val userId = 1L
         val challengeId = 1L
         val feedId = 1L
+        val commentId = 1L
 
         every { challengeRepository.findInfoById(any()) } returns challenge
         every { feedRepository.findByFeedId(any()) } returns feed
@@ -752,7 +751,7 @@ class ChallengeServiceTest : AbstractMailProperties {
 
         // when & then
         assertThatThrownBy {
-            challengeService.deleteChallengeFeedComment(userId, challengeId, feedId)
+            challengeService.deleteChallengeFeedComment(userId, challengeId, feedId, commentId)
         }
             .isInstanceOf(CustomException::class.java)
             .extracting("exceptionCode")
@@ -772,17 +771,18 @@ class ChallengeServiceTest : AbstractMailProperties {
         val userId = 1L
         val challengeId = 1L
         val feedId = 1L
+        val commentId = 1L
 
         every { challengeRepository.findInfoById(any()) } returns challenge
         every { feedRepository.findByFeedId(any()) } returns feed
         every {
             challengeMemberRepository.findByUserIdAndChallengeId(userId, challengeId)
         } returns challengeMember
-        every { feedCommentRepository.findByChallengeMemberIdAndFeedId(any(), any()) } returns null
+        every { feedCommentRepository.findByCommentId(any()) } returns null
 
         // when & then
         assertThatThrownBy {
-            challengeService.deleteChallengeFeedComment(userId, challengeId, feedId)
+            challengeService.deleteChallengeFeedComment(userId, challengeId, feedId, commentId)
         }
             .isInstanceOf(CustomException::class.java)
             .extracting("exceptionCode")


### PR DESCRIPTION
## 📋 이슈 번호
- close #137 
  </br>

## 🛠 구현 사항
- 피드 댓글 id path variable에 추가
- 피드 댓글 id로 조회하고 삭제
  </br>

## 📚 기타
- 
  </br>