### PR TITLE
[feat] 피드 개별 조회 API

### DIFF
--- a/src/main/kotlin/com/alloon/alloonserver/api/controller/challenge/ChallengeController.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/api/controller/challenge/ChallengeController.kt
@@ -277,4 +277,23 @@ class ChallengeController(
 
         return ResponseEntity.ok(StringSuccessResponse("챌린지 피드 댓글 삭제가 완료되었습니다."))
     }
+
+    @GetMapping("/{challengeId}/feeds/{feedId}")
+    @Operation(summary = "챌린지 피드 개별 조회", security = [SecurityRequirement(name = ACCESS_TOKEN_KEY)])
+    @ApiResponse(responseCode = "200")
+    @ApiErrorResponses([TOKEN_UNAUTHENTICATED, TOKEN_UNAUTHORIZED, CHALLENGE_NOT_FOUND, CHALLENGE_MEMBER_NOT_FOUND, FEED_NOT_FOUND])
+    fun findChallengeFeed(
+        principal: Principal,
+        @PathVariable @Parameter(description = "챌린지 id", example = "1") challengeId: Long,
+        @PathVariable @Parameter(description = "피드 id", example = "1") feedId: Long,
+    ): ResponseEntity<FindChallengeFeedResponse> {
+        val challengeFeed = challengeService.findChallengeFeed(
+            UserUtility.getUserId(principal),
+            challengeId,
+            feedId
+        )
+        val response = FindChallengeFeedResponse.of(challengeFeed)
+
+        return ResponseEntity.ok(response)
+    }
 }

--- a/src/main/kotlin/com/alloon/alloonserver/api/controller/challenge/response/FindChallengeFeedResponse.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/api/controller/challenge/response/FindChallengeFeedResponse.kt
@@ -1,0 +1,38 @@
+package com.alloon.alloonserver.api.controller.challenge.response
+
+import com.alloon.alloonserver.service.challenge.dto.FindChallengeFeedDto
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDateTime
+
+@Schema(description = "챌린지 피드 개별 조회 응답 객체")
+data class FindChallengeFeedResponse(
+
+    @Schema(description = "사용자 아이디", example = "photi")
+    val username: String,
+
+    @Schema(description = "사용자 이미지", example = "https://url.kr/5MhHhD")
+    val userImageUrl: String,
+
+    @Schema(description = "피드 이미지", example = "https://url.kr/5MhHhD")
+    val feedImageUrl: String,
+
+    @Schema(description = "피드 인증 날짜 시간")
+    val createdDateTime: LocalDateTime,
+
+    @Schema(description = "피드 하트 수", example = "10")
+    val likeCnt: Int,
+) {
+
+    companion object {
+
+        fun of(feed: FindChallengeFeedDto): FindChallengeFeedResponse {
+            return FindChallengeFeedResponse(
+                feed.username,
+                feed.userImageUrl,
+                feed.feedImageUrl,
+                feed.createdDateTime,
+                feed.likeCnt,
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/alloon/alloonserver/domain/feed/custom/FeedCustomRepository.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/domain/feed/custom/FeedCustomRepository.kt
@@ -2,6 +2,7 @@ package com.alloon.alloonserver.domain.feed.custom
 
 import com.alloon.alloonserver.common.constant.SortTypeConstants
 import com.alloon.alloonserver.domain.feed.Feed
+import com.alloon.alloonserver.service.challenge.dto.FindChallengeFeedDto
 import com.alloon.alloonserver.service.challenge.dto.FindChallengeFeedsDto
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Slice
@@ -12,6 +13,8 @@ interface FeedCustomRepository {
     fun find(id: Long): Feed?
 
     fun findByFeedId(id: Long): Feed?
+
+    fun findContentById(id: Long): FindChallengeFeedDto?
 
     fun findAllByChallengeId(
         challengeId: Long,

--- a/src/main/kotlin/com/alloon/alloonserver/domain/feed/custom/FeedCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/domain/feed/custom/FeedCustomRepositoryImpl.kt
@@ -7,7 +7,9 @@ import com.alloon.alloonserver.domain.base.ServiceStatus
 import com.alloon.alloonserver.domain.base.ServiceStatus.ACTIVE
 import com.alloon.alloonserver.domain.feed.Feed
 import com.alloon.alloonserver.domain.feed.QFeed.feed
+import com.alloon.alloonserver.service.challenge.dto.FindChallengeFeedDto
 import com.alloon.alloonserver.service.challenge.dto.FindChallengeFeedsDto
+import com.alloon.alloonserver.service.challenge.dto.QFindChallengeFeedDto
 import com.alloon.alloonserver.service.challenge.dto.QFindChallengeFeedsDto
 import com.querydsl.core.types.Order.DESC
 import com.querydsl.core.types.OrderSpecifier
@@ -37,6 +39,23 @@ class FeedCustomRepositoryImpl(
         return queryFactory
             .selectFrom(feed)
             .join(feed.challengeMember).fetchJoin()
+            .where(feed.id.eq(id))
+            .fetchFirst()
+    }
+
+    override fun findContentById(id: Long): FindChallengeFeedDto? {
+        return queryFactory
+            .select(
+                QFindChallengeFeedDto(
+                    feed.challengeMember.user.username,
+                    feed.challengeMember.user.imageUrl,
+                    feed.imageUrl,
+                    feed.createDateTime,
+                    feed.likeCnt,
+                )
+            )
+            .from(feed)
+            .join(feed.challengeMember)
             .where(feed.id.eq(id))
             .fetchFirst()
     }

--- a/src/main/kotlin/com/alloon/alloonserver/service/challenge/ChallengeService.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/service/challenge/ChallengeService.kt
@@ -200,6 +200,12 @@ class ChallengeService(
         feed.decreaseCommentCnt()
     }
 
+    fun findChallengeFeed(userId: Long, challengeId: Long, feedId: Long): FindChallengeFeedDto {
+        validateChallenge(challengeId)
+        validateChallengeMember(userId, challengeId)
+        return feedRepository.findContentById(feedId) ?: throw CustomException(FEED_NOT_FOUND)
+    }
+
     private fun validateUser(userId: Long): User {
         return userRepository.find(userId) ?: throw CustomException(USER_NOT_FOUND)
     }

--- a/src/main/kotlin/com/alloon/alloonserver/service/challenge/dto/FindChallengeFeedDto.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/service/challenge/dto/FindChallengeFeedDto.kt
@@ -1,0 +1,12 @@
+package com.alloon.alloonserver.service.challenge.dto
+
+import com.querydsl.core.annotations.QueryProjection
+import java.time.LocalDateTime
+
+data class FindChallengeFeedDto @QueryProjection constructor(
+    val username: String,
+    val userImageUrl: String,
+    val feedImageUrl: String,
+    val createdDateTime: LocalDateTime,
+    val likeCnt: Int,
+)

--- a/src/test/kotlin/com/alloon/alloonserver/api/controller/challenge/ChallengeControllerTest.kt
+++ b/src/test/kotlin/com/alloon/alloonserver/api/controller/challenge/ChallengeControllerTest.kt
@@ -356,6 +356,25 @@ class ChallengeControllerTest : RestDocsSupport() {
         resultActions.andExpect(status().isOk)
     }
 
+    @DisplayName("챌린지 피드 개별 조회를 성공하면 200을 반환한다.")
+    @Test
+    fun givenValid_whenFindChallengeFeed_thenReturn200() {
+        // given
+        val dto = getFindChallengeFeedDto()
+        every { challengeService.findChallengeFeed(any(), any(), any()) } returns dto
+
+        // when
+        val resultActions = mockMvc.perform(
+            get("/api/challenges/{challengeId}/feeds/{feedId}", 1, 1)
+                .header(AUTHORIZATION, "Bearer access-token")
+                .principal(mockPrincipal)
+                .contentType(APPLICATION_JSON)
+        )
+
+        // then
+        resultActions.andExpect(status().isOk)
+    }
+
     private fun getCreateChallengeRequest(): CreateChallengeRequest {
         return CreateChallengeRequest(
             "챌린지 이름",
@@ -450,6 +469,16 @@ class ChallengeControllerTest : RestDocsSupport() {
             "https://url.kr/5MhHhD",
             LocalDateTime.now(),
             LocalTime.of(13, 0),
+        )
+    }
+
+    private fun getFindChallengeFeedDto(): FindChallengeFeedDto {
+        return FindChallengeFeedDto(
+            "tester",
+            "https://url.kr/5MhHhD",
+            "https://url.kr/5MhHhD",
+            LocalDateTime.now(),
+            10
         )
     }
 }

--- a/src/test/kotlin/com/alloon/alloonserver/service/challenge/ChallengeServiceTest.kt
+++ b/src/test/kotlin/com/alloon/alloonserver/service/challenge/ChallengeServiceTest.kt
@@ -789,6 +789,93 @@ class ChallengeServiceTest : AbstractMailProperties {
             .isEqualTo(FEED_COMMENT_NOT_FOUND)
     }
 
+    @DisplayName("챌린지 피드 개별 조회를 하면 일치하는 피드를 반환한다.")
+    @Test
+    fun givenValid_whenFindChallengeFeed_thenReturn() {
+        // given
+        val userId = 1L
+        val challengeId = 1L
+        val feedId = 1L
+        val user = getUser()
+        val challenge = getCreateChallengeDto().toEntity("https://url.kr/5MhHhD")
+        val challengeMember = ChallengeMember(user = user, challenge = challenge)
+        val dto = getFindChallengeFeedDto()
+
+        every { challengeRepository.findInfoById(any()) } returns challenge
+        every {
+            challengeMemberRepository.findByUserIdAndChallengeId(userId, challengeId)
+        } returns challengeMember
+        every { feedRepository.findContentById(any()) } returns dto
+
+        // when
+        val result = challengeService.findChallengeFeed(userId, challengeId, feedId)
+
+        // then
+        assertThat(result).isEqualTo(dto)
+    }
+
+    @DisplayName("등록되지 않은 챌린지의 피드를 개별 조회하면 예외가 발생한다.")
+    @Test
+    fun givenNotFoundChallenge_whenFindChallengeFeed_thenReturn() {
+        // given
+        val userId = 1L
+        val challengeId = 1L
+        val feedId = 1L
+
+        every { challengeRepository.findInfoById(any()) } returns null
+
+        // when & then
+        assertThatThrownBy { challengeService.findChallengeFeed(userId, challengeId, feedId) }
+            .isInstanceOf(CustomException::class.java)
+            .extracting("exceptionCode")
+            .isEqualTo(CHALLENGE_NOT_FOUND)
+    }
+
+    @DisplayName("등록되지 않은 챌린지 파티원이 피드를 개별 조회하면 예외가 발생한다.")
+    @Test
+    fun givenNotFoundChallengeMember_whenFindChallengeFeed_thenReturn() {
+        // given
+        val userId = 1L
+        val challengeId = 1L
+        val feedId = 1L
+        val challenge = getCreateChallengeDto().toEntity("https://url.kr/5MhHhD")
+
+        every { challengeRepository.findInfoById(any()) } returns challenge
+        every {
+            challengeMemberRepository.findByUserIdAndChallengeId(userId, challengeId)
+        } returns null
+
+        // when & then
+        assertThatThrownBy { challengeService.findChallengeFeed(userId, challengeId, feedId) }
+            .isInstanceOf(CustomException::class.java)
+            .extracting("exceptionCode")
+            .isEqualTo(CHALLENGE_MEMBER_NOT_FOUND)
+    }
+
+    @DisplayName("등록되지 않은 피드를 개별 조회하면 예외가 발생한다.")
+    @Test
+    fun givenNotFoundFeed_whenFindChallengeFeed_thenReturn() {
+        // given
+        val userId = 1L
+        val challengeId = 1L
+        val feedId = 1L
+        val user = getUser()
+        val challenge = getCreateChallengeDto().toEntity("https://url.kr/5MhHhD")
+        val challengeMember = ChallengeMember(user = user, challenge = challenge)
+
+        every { challengeRepository.findInfoById(any()) } returns challenge
+        every {
+            challengeMemberRepository.findByUserIdAndChallengeId(userId, challengeId)
+        } returns challengeMember
+        every { feedRepository.findContentById(any()) } returns null
+
+        // when & then
+        assertThatThrownBy { challengeService.findChallengeFeed(userId, challengeId, feedId) }
+            .isInstanceOf(CustomException::class.java)
+            .extracting("exceptionCode")
+            .isEqualTo(FEED_NOT_FOUND)
+    }
+
     private fun getUser(): User {
         val contact = Contact(1L, "tester@photi.com", "000000", true)
         return User(1L, contact, "tester", "password1!", "")
@@ -889,6 +976,16 @@ class ChallengeServiceTest : AbstractMailProperties {
             "https://url.kr/5MhHhD",
             LocalDateTime.now(),
             LocalTime.of(13, 0),
+        )
+    }
+
+    private fun getFindChallengeFeedDto(): FindChallengeFeedDto {
+        return FindChallengeFeedDto(
+            "tester",
+            "https://url.kr/5MhHhD",
+            "https://url.kr/5MhHhD",
+            LocalDateTime.now(),
+            10
         )
     }
 }


### PR DESCRIPTION
## 📋 이슈 번호
- close #130 
  </br>

## 🛠 구현 사항
- 사용자 아이디, 사용자 이미지, 피드 이미지, 피드 인증 날짜 시간, 피드 하트 수 조회
  </br>

## 📚 기타
- 
  </br>