### PR TITLE
[feat] 사용자 참여 중인 챌린지 갯수 조회 API

### DIFF
--- a/src/main/kotlin/com/alloon/alloonserver/api/controller/user/UserController.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/api/controller/user/UserController.kt
@@ -1,5 +1,6 @@
 package com.alloon.alloonserver.api.controller.user
 
+import com.alloon.alloonserver.api.controller.user.response.FindUserChallengeCntResponse
 import com.alloon.alloonserver.api.controller.user.response.UserChallengeHistoryResponse
 import com.alloon.alloonserver.api.controller.user.response.UserInfoResponse
 import com.alloon.alloonserver.common.constant.ExceptionCode.*
@@ -78,5 +79,19 @@ class UserController(
         val response = userService.findUserFeeds(UserUtility.getUserId(principal))
 
         return ResponseEntity.ok(CollectionSuccessResponse(response))
+    }
+
+    @GetMapping("/challenges")
+    @Operation(
+        summary = "사용자 참여 중인 챌린지 갯수 조회",
+        security = [SecurityRequirement(name = ACCESS_TOKEN_KEY)]
+    )
+    @ApiResponse(responseCode = "200")
+    @ApiErrorResponses([TOKEN_UNAUTHENTICATED, TOKEN_UNAUTHORIZED, USER_NOT_FOUND])
+    fun findUserChallengeCnt(principal: Principal): ResponseEntity<FindUserChallengeCntResponse> {
+        val userChallenge = userService.findUserChallengeCnt(UserUtility.getUserId(principal))
+        val response = FindUserChallengeCntResponse.of(userChallenge)
+
+        return ResponseEntity.ok(response)
     }
 }

--- a/src/main/kotlin/com/alloon/alloonserver/api/controller/user/response/FindUserChallengeCntResponse.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/api/controller/user/response/FindUserChallengeCntResponse.kt
@@ -1,0 +1,22 @@
+package com.alloon.alloonserver.api.controller.user.response
+
+import com.alloon.alloonserver.service.user.dto.FindUserChallengeCntDto
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "사용자 참여 중인 챌린지 갯수 응답 객체")
+data class FindUserChallengeCntResponse(
+
+    @Schema(description = "사용자 아이디", example = "photi")
+    val username: String,
+
+    @Schema(description = "사용자 참여 중인 챌린지 갯수", example = "5")
+    val challengeCnt: Int,
+) {
+
+    companion object {
+
+        fun of(userChallenge: FindUserChallengeCntDto): FindUserChallengeCntResponse {
+            return FindUserChallengeCntResponse(userChallenge.username, userChallenge.challengeCnt)
+        }
+    }
+}

--- a/src/main/kotlin/com/alloon/alloonserver/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/config/SecurityConfig.kt
@@ -38,6 +38,7 @@ class SecurityConfig(
                     "/api/users/image",
                     "/api/users/challenge-history",
                     "/api/users/feeds",
+                    "/api/users/challenges",
                     "/api/challenges/{challengeId}/info",
                     "/api/challenges/{challengeId}/challenge-members/goal",
                     "/api/challenges/{challengeId}/challenge-members",

--- a/src/main/kotlin/com/alloon/alloonserver/domain/user/custom/UserCustomRepository.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/domain/user/custom/UserCustomRepository.kt
@@ -1,6 +1,7 @@
 package com.alloon.alloonserver.domain.user.custom
 
 import com.alloon.alloonserver.domain.user.User
+import com.alloon.alloonserver.service.user.dto.FindUserChallengeCntDto
 import com.alloon.alloonserver.service.user.dto.UserChallengeHistoryDto
 import com.alloon.alloonserver.service.user.dto.UserInfoDto
 
@@ -15,4 +16,6 @@ interface UserCustomRepository {
     fun findChallengeHistoryById(userId: Long): UserChallengeHistoryDto?
 
     fun findFeedsById(userId: Long): List<String>?
+
+    fun findChallengeCntById(userId: Long): FindUserChallengeCntDto?
 }

--- a/src/main/kotlin/com/alloon/alloonserver/domain/user/custom/UserCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/domain/user/custom/UserCustomRepositoryImpl.kt
@@ -6,10 +6,7 @@ import com.alloon.alloonserver.domain.feed.QFeed.feed
 import com.alloon.alloonserver.domain.user.QContact.contact
 import com.alloon.alloonserver.domain.user.QUser.user
 import com.alloon.alloonserver.domain.user.User
-import com.alloon.alloonserver.service.user.dto.QUserChallengeHistoryDto
-import com.alloon.alloonserver.service.user.dto.QUserInfoDto
-import com.alloon.alloonserver.service.user.dto.UserChallengeHistoryDto
-import com.alloon.alloonserver.service.user.dto.UserInfoDto
+import com.alloon.alloonserver.service.user.dto.*
 import com.querydsl.core.types.dsl.BooleanExpression
 import com.querydsl.core.types.dsl.Expressions
 import com.querydsl.jpa.impl.JPAQueryFactory
@@ -90,6 +87,21 @@ class UserCustomRepositoryImpl(
 
         return queryFactory
             .select(Expressions.constant(feeds))
+            .from(user)
+            .where(user.id.eq(userId))
+            .fetchOne()
+    }
+
+    override fun findChallengeCntById(userId: Long): FindUserChallengeCntDto? {
+        val challengeCnt = queryFactory
+            .select(challengeMember.count())
+            .from(challengeMember)
+            .join(challengeMember.user)
+            .where(challengeMember.user.id.eq(userId))
+            .fetchOne()?.toInt() ?: 0
+
+        return queryFactory
+            .select(QFindUserChallengeCntDto(user.username, Expressions.constant(challengeCnt)))
             .from(user)
             .where(user.id.eq(userId))
             .fetchOne()

--- a/src/main/kotlin/com/alloon/alloonserver/service/user/UserService.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/service/user/UserService.kt
@@ -5,6 +5,7 @@ import com.alloon.alloonserver.common.response.CustomException
 import com.alloon.alloonserver.domain.user.UserRepository
 import com.alloon.alloonserver.service.s3.FolderType.USERS
 import com.alloon.alloonserver.service.s3.S3Service
+import com.alloon.alloonserver.service.user.dto.FindUserChallengeCntDto
 import com.alloon.alloonserver.service.user.dto.UserChallengeHistoryDto
 import com.alloon.alloonserver.service.user.dto.UserInfoDto
 import org.springframework.stereotype.Service
@@ -45,6 +46,10 @@ class UserService(
     fun findUserFeeds(userId: Long): List<String> {
         return userRepository.findFeedsById(userId)?.distinct()
             ?: throw CustomException(USER_NOT_FOUND)
+    }
+
+    fun findUserChallengeCnt(userId: Long): FindUserChallengeCntDto {
+        return userRepository.findChallengeCntById(userId) ?: throw CustomException(USER_NOT_FOUND)
     }
 
     private fun deleteOriginalImage(imageUrl: String) {

--- a/src/main/kotlin/com/alloon/alloonserver/service/user/dto/FindUserChallengeCntDto.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/service/user/dto/FindUserChallengeCntDto.kt
@@ -1,0 +1,8 @@
+package com.alloon.alloonserver.service.user.dto
+
+import com.querydsl.core.annotations.QueryProjection
+
+data class FindUserChallengeCntDto @QueryProjection constructor(
+    val username: String,
+    val challengeCnt: Int,
+)

--- a/src/test/kotlin/com/alloon/alloonserver/api/controller/user/UserControllerTest.kt
+++ b/src/test/kotlin/com/alloon/alloonserver/api/controller/user/UserControllerTest.kt
@@ -2,6 +2,7 @@ package com.alloon.alloonserver.api.controller.user
 
 import com.alloon.alloonserver.api.controller.RestDocsSupport
 import com.alloon.alloonserver.service.user.UserService
+import com.alloon.alloonserver.service.user.dto.FindUserChallengeCntDto
 import com.alloon.alloonserver.service.user.dto.UserChallengeHistoryDto
 import com.alloon.alloonserver.service.user.dto.UserInfoDto
 import io.mockk.every
@@ -93,6 +94,25 @@ class UserControllerTest : RestDocsSupport() {
         // when
         val resultActions = mockMvc.perform(
             get("/api/users/feeds")
+                .header(AUTHORIZATION, "Bearer access-token")
+                .principal(mockPrincipal)
+        )
+
+        // then
+        resultActions.andExpect(status().isOk)
+    }
+
+    @DisplayName("사용자 참여 중인 챌린지 갯수 조회를 성공하면 200을 반환한다.")
+    @Test
+    fun givenValid_whenFindUserChallengeCnt_thenReturn200() {
+        // given
+        val dto = FindUserChallengeCntDto("tester", 5)
+
+        every { userService.findUserChallengeCnt(any()) } returns dto
+
+        // when
+        val resultActions = mockMvc.perform(
+            get("/api/users/challenges")
                 .header(AUTHORIZATION, "Bearer access-token")
                 .principal(mockPrincipal)
         )

--- a/src/test/kotlin/com/alloon/alloonserver/service/user/UserServiceTest.kt
+++ b/src/test/kotlin/com/alloon/alloonserver/service/user/UserServiceTest.kt
@@ -7,6 +7,7 @@ import com.alloon.alloonserver.domain.user.User
 import com.alloon.alloonserver.domain.user.UserRepository
 import com.alloon.alloonserver.framework.TestContainerInitializer
 import com.alloon.alloonserver.service.s3.S3Service
+import com.alloon.alloonserver.service.user.dto.FindUserChallengeCntDto
 import com.alloon.alloonserver.service.user.dto.UserChallengeHistoryDto
 import com.alloon.alloonserver.service.user.dto.UserInfoDto
 import io.mockk.Runs
@@ -159,6 +160,37 @@ class UserServiceTest {
 
         // when & then
         assertThatThrownBy { userService.findUserFeeds(userId) }
+            .isInstanceOf(CustomException::class.java)
+            .extracting("exceptionCode")
+            .isEqualTo(USER_NOT_FOUND)
+    }
+
+    @DisplayName("사용자 참여 중인 챌린지 갯수 조회를 하면 일치하는 사용자 챌린지 갯수를 반환한다.")
+    @Test
+    fun givenValid_whenFindUserChallengeCnt_thenReturn() {
+        // given
+        val userId = 1L
+        val userChallenge = FindUserChallengeCntDto("tester", 5)
+
+        every { userRepository.findChallengeCntById(any()) } returns userChallenge
+
+        // when
+        val result = userService.findUserChallengeCnt(userId)
+
+        // then
+        assertThat(result).isEqualTo(userChallenge)
+    }
+
+    @DisplayName("존재하지 않은 사용자로 참여 중인 챌린지 갯수 조회를 하면 예외가 발생한다.")
+    @Test
+    fun givenNotFoundUser_whenFindUserChallengeCnt_thenThrow() {
+        // given
+        val userId = 1L
+
+        every { userRepository.findChallengeCntById(any()) } returns null
+
+        // when & then
+        assertThatThrownBy { userService.findUserChallengeCnt(userId) }
             .isInstanceOf(CustomException::class.java)
             .extracting("exceptionCode")
             .isEqualTo(USER_NOT_FOUND)


### PR DESCRIPTION
## 📋 이슈 번호
- close #145 
  </br>

## 🛠 구현 사항
- 사용자가 참여 중인 챌린지 갯수 조회
  - userid와 일치하는 챌린지 파티원 수로 조회
  </br>

## 📚 기타
- 
  </br>