### PR TITLE
[refactor] 지금 인기있는 챌린지 조회 API 수정

### DIFF
--- a/src/main/kotlin/com/alloon/alloonserver/api/controller/challenge/ChallengeController.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/api/controller/challenge/ChallengeController.kt
@@ -65,7 +65,7 @@ class ChallengeController(
     @GetMapping("/popular")
     @Operation(
         summary = "지금 인기있는 챌린지 조회",
-        description = "공개, 비공개 및 종료되지 않은 챌린지가 방문순으로 최대 5개 조회됩니다."
+        description = "공개, 비공개 및 종료되지 않은 챌린지가 방문순으로 최대 5개 조회됩니다. 챌린지 파티원 이미지는 최근 가입순으로 최대 3개 조회됩니다."
     )
     @ApiResponse(responseCode = "200")
     fun findPopularChallenges(): ResponseEntity<List<FindPopularChallengesResponse>> {

--- a/src/main/kotlin/com/alloon/alloonserver/api/controller/challenge/response/FindPopularChallengesResponse.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/api/controller/challenge/response/FindPopularChallengesResponse.kt
@@ -20,6 +20,9 @@ data class FindPopularChallengesResponse(
     @Schema(description = "챌린지 목표", example = "하루에 한 번씩 꼭 러닝을 하는 것이 우리 챌린지의 목표입니다.")
     val goal: String,
 
+    @Schema(description = "챌린지 파티원 수", example = "5")
+    val currentMemberCnt: Int,
+
     @Schema(description = "챌린지 인증 시간", example = "13:00")
     @field:JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "kk:mm")
     val proveTime: LocalTime,
@@ -37,6 +40,17 @@ data class FindPopularChallengesResponse(
     """
     )
     val hashtags: List<ChallengeHashtagResponse>,
+
+    @Schema(
+        description = "챌린지 파티원 이미지 리스트", example = """
+        [
+            {"memberImage": "https://url.kr/5MhHhD"},
+            {"memberImage": "https://url.kr/5MhHhD"},
+            {"memberImage": "https://url.kr/5MhHhD"}
+        ]
+    """
+    )
+    val memberImages: List<ChallengeMemberImageResponse>,
 ) {
 
     companion object {
@@ -47,9 +61,11 @@ data class FindPopularChallengesResponse(
                 challenge.name,
                 challenge.imageUrl,
                 challenge.goal,
+                challenge.currentMemberCnt,
                 challenge.proveTime,
                 challenge.endDate,
-                challenge.hashtags.map { ChallengeHashtagResponse(it) }
+                challenge.hashtags.map { ChallengeHashtagResponse(it) },
+                challenge.memberImages.map { ChallengeMemberImageResponse(it) },
             )
         }
 

--- a/src/main/kotlin/com/alloon/alloonserver/domain/challenge/custom/ChallengeCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/domain/challenge/custom/ChallengeCustomRepositoryImpl.kt
@@ -4,11 +4,13 @@ import com.alloon.alloonserver.domain.base.ServiceStatus
 import com.alloon.alloonserver.domain.base.ServiceStatus.ACTIVE
 import com.alloon.alloonserver.domain.challenge.Challenge
 import com.alloon.alloonserver.domain.challenge.QChallenge.challenge
+import com.alloon.alloonserver.domain.challenge.QChallengeMember.challengeMember
 import com.alloon.alloonserver.service.challenge.dto.FindChallengesDto
 import com.alloon.alloonserver.service.challenge.dto.FindPopularChallengesDto
 import com.alloon.alloonserver.service.challenge.dto.QFindChallengesDto
 import com.alloon.alloonserver.service.challenge.dto.QFindPopularChallengesDto
 import com.querydsl.core.types.dsl.BooleanExpression
+import com.querydsl.core.types.dsl.Expressions
 import com.querydsl.jpa.impl.JPAQueryFactory
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Slice
@@ -30,16 +32,18 @@ class ChallengeCustomRepositoryImpl(
     }
 
     override fun findPopular(): List<FindPopularChallengesDto> {
-        return queryFactory
+        val popularChallenges = queryFactory
             .select(
                 QFindPopularChallengesDto(
                     challenge.id,
                     challenge.name,
                     challenge.imageUrl,
                     challenge.goal,
+                    challenge.currentMemberCnt,
                     challenge.proveTime,
                     challenge.endDate,
                     challenge.hashtags,
+                    Expressions.constant(emptyList()),
                 )
             )
             .from(challenge)
@@ -47,6 +51,18 @@ class ChallengeCustomRepositoryImpl(
             .orderBy(challenge.visitCnt.desc())
             .limit(5)
             .fetch()
+
+        popularChallenges.forEach {
+            it.memberImages = queryFactory
+                .select(challengeMember.user.imageUrl)
+                .from(challengeMember)
+                .where(challengeMember.challenge.id.eq(it.id))
+                .orderBy(challengeMember.createDateTime.desc())
+                .limit(3)
+                .fetch()
+        }
+
+        return popularChallenges
     }
 
     override fun findInfoById(id: Long): Challenge? {

--- a/src/main/kotlin/com/alloon/alloonserver/service/challenge/dto/FindPopularChallengesDto.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/service/challenge/dto/FindPopularChallengesDto.kt
@@ -9,7 +9,9 @@ data class FindPopularChallengesDto @QueryProjection constructor(
     val name: String,
     val imageUrl: String,
     val goal: String,
+    val currentMemberCnt: Int,
     val proveTime: LocalTime,
     val endDate: LocalDate,
     val hashtags: List<String>,
+    var memberImages: List<String>,
 )

--- a/src/test/kotlin/com/alloon/alloonserver/api/controller/challenge/ChallengeControllerTest.kt
+++ b/src/test/kotlin/com/alloon/alloonserver/api/controller/challenge/ChallengeControllerTest.kt
@@ -424,9 +424,11 @@ class ChallengeControllerTest : RestDocsSupport() {
             "챌린지 이름",
             "https://url.kr/5MhHhD",
             "챌린지 목표입니다.",
+            3,
             LocalTime.of(13, 0),
             LocalDate.of(2024, 12, 1),
             listOf("해시태그 1", "해시태그 2"),
+            listOf("https://url.kr/5MhHhD", "https://url.kr/5MhHhD", "https://url.kr/5MhHhD")
         )
     }
 

--- a/src/test/kotlin/com/alloon/alloonserver/service/challenge/ChallengeServiceTest.kt
+++ b/src/test/kotlin/com/alloon/alloonserver/service/challenge/ChallengeServiceTest.kt
@@ -931,9 +931,11 @@ class ChallengeServiceTest : AbstractMailProperties {
             "챌린지 이름",
             "https://url.kr/5MhHhD",
             "챌린지 목표입니다.",
+            3,
             LocalTime.of(13, 0),
             LocalDate.of(2024, 12, 1),
             listOf("해시태그 1", "해시태그 2"),
+            listOf("https://url.kr/5MhHhD", "https://url.kr/5MhHhD", "https://url.kr/5MhHhD")
         )
     }
 


### PR DESCRIPTION
## 📋 이슈 번호
- close #147 
  </br>

## 🛠 구현 사항
- 챌린지 파티원 수, 파티원 이미지 리스트 추가 조회
  </br>

## 📚 기타
- 
  </br>