### PR TITLE
[feat] 인증 개별 날짜 조회 API

### DIFF
--- a/src/main/kotlin/com/alloon/alloonserver/api/controller/user/UserController.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/api/controller/user/UserController.kt
@@ -1,6 +1,7 @@
 package com.alloon.alloonserver.api.controller.user
 
 import com.alloon.alloonserver.api.controller.user.response.FindUserChallengeCntResponse
+import com.alloon.alloonserver.api.controller.user.response.FindUserFeedsByDateResponse
 import com.alloon.alloonserver.api.controller.user.response.UserChallengeHistoryResponse
 import com.alloon.alloonserver.api.controller.user.response.UserInfoResponse
 import com.alloon.alloonserver.common.constant.ExceptionCode.*
@@ -10,6 +11,7 @@ import com.alloon.alloonserver.common.util.UserUtility
 import com.alloon.alloonserver.config.SwaggerConfig.Companion.ACCESS_TOKEN_KEY
 import com.alloon.alloonserver.service.user.UserService
 import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.tags.Tag
@@ -19,6 +21,7 @@ import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.*
 import org.springframework.web.multipart.MultipartFile
 import java.security.Principal
+import java.time.LocalDate
 
 @Validated
 @RestController
@@ -91,6 +94,23 @@ class UserController(
     fun findUserChallengeCnt(principal: Principal): ResponseEntity<FindUserChallengeCntResponse> {
         val userChallenge = userService.findUserChallengeCnt(UserUtility.getUserId(principal))
         val response = FindUserChallengeCntResponse.of(userChallenge)
+
+        return ResponseEntity.ok(response)
+    }
+
+    @GetMapping("/feeds/date")
+    @Operation(
+        summary = "사용자 피드 인증 개별 날짜 조회",
+        security = [SecurityRequirement(name = ACCESS_TOKEN_KEY)]
+    )
+    @ApiResponse(responseCode = "200")
+    @ApiErrorResponses([TOKEN_UNAUTHENTICATED, TOKEN_UNAUTHORIZED, DATE_FORMAT_INVALID])
+    fun findUserFeedsByDate(
+        principal: Principal,
+        @RequestParam @Parameter(description = "인증 날짜", example = "2024-10-23") date: LocalDate,
+    ): ResponseEntity<List<FindUserFeedsByDateResponse>> {
+        val userFeeds = userService.findUserFeedsByDate(UserUtility.getUserId(principal), date)
+        val response = FindUserFeedsByDateResponse.of(userFeeds)
 
         return ResponseEntity.ok(response)
     }

--- a/src/main/kotlin/com/alloon/alloonserver/api/controller/user/response/FindUserFeedsByDateResponse.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/api/controller/user/response/FindUserFeedsByDateResponse.kt
@@ -1,0 +1,35 @@
+package com.alloon.alloonserver.api.controller.user.response
+
+import com.alloon.alloonserver.service.user.dto.FindUserFeedsByDateDto
+import com.fasterxml.jackson.annotation.JsonFormat
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalTime
+
+@Schema(description = "사용자 피드 인증 개별 날짜 조회 응답 객체")
+data class FindUserFeedsByDateResponse(
+
+    @Schema(description = "피드 id", example = "1")
+    val id: Long,
+
+    @Schema(description = "피드 이미지", example = "https://url.kr/5MhHhD")
+    val imageUrl: String,
+
+    @Schema(description = "챌린지 이름", example = "신나게 하는 러닝 챌린지")
+    val name: String,
+
+    @Schema(description = "챌린지 인증 시간", example = "13:00")
+    @field:JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "kk:mm")
+    val proveTime: LocalTime,
+) {
+
+    companion object {
+
+        fun of(feed: FindUserFeedsByDateDto): FindUserFeedsByDateResponse {
+            return FindUserFeedsByDateResponse(feed.id, feed.imageUrl, feed.name, feed.proveTime)
+        }
+
+        fun of(feeds: List<FindUserFeedsByDateDto>): List<FindUserFeedsByDateResponse> {
+            return feeds.map { of(it) }
+        }
+    }
+}

--- a/src/main/kotlin/com/alloon/alloonserver/common/constant/ExceptionCode.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/common/constant/ExceptionCode.kt
@@ -53,6 +53,7 @@ enum class ExceptionCode(
     PASSWORD_FORMAT_INVALID(BAD_REQUEST, "비밀번호는 영어, 숫자, 특수문자(#$@!%&*)의 조합으로 입력해 주세요."),
     NEW_PASSWORD_FORMAT_INVALID(BAD_REQUEST, "비밀번호는 영어, 숫자, 특수문자(#$@!%&*)의 조합으로 입력해 주세요."),
     REPORT_TYPE_INVALID(BAD_REQUEST, "신고 타입은 'CHALLENGE', 'CHALLENGE_MEMBER', 'FEED' 중 하나여야 됩니다."),
+    DATE_FORMAT_INVALID(BAD_REQUEST, "올바르지 않은 날짜 형식입니다."),
 
     // @Positive, @PositiveOrZero
 

--- a/src/main/kotlin/com/alloon/alloonserver/common/exception/CustomExceptionHandler.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/common/exception/CustomExceptionHandler.kt
@@ -1,12 +1,13 @@
 package com.alloon.alloonserver.common.exception
 
-import com.alloon.alloonserver.common.constant.ExceptionCode.FILE_SIZE_EXCEED
-import com.alloon.alloonserver.common.constant.ExceptionCode.SERVER_ERROR
+import com.alloon.alloonserver.common.constant.ExceptionCode
+import com.alloon.alloonserver.common.constant.ExceptionCode.*
 import com.alloon.alloonserver.common.response.CustomException
 import com.alloon.alloonserver.common.response.ErrorResponse
 import io.sentry.Sentry
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.validation.ConstraintViolationException
+import org.springframework.beans.TypeMismatchException
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus.*
 import org.springframework.http.HttpStatusCode
@@ -16,8 +17,11 @@ import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
 import org.springframework.web.context.request.WebRequest
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException
 import org.springframework.web.multipart.MaxUploadSizeExceededException
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler
+import java.time.format.DateTimeParseException
+
 
 @RestControllerAdvice
 class CustomExceptionHandler : ResponseEntityExceptionHandler() {
@@ -83,6 +87,16 @@ class CustomExceptionHandler : ResponseEntityExceptionHandler() {
         val message = ex.mostSpecificCause.message.toString()
         val response = ErrorResponse(status.toString().split(" ")[1], message)
 
+        return ResponseEntity.status(BAD_REQUEST).body(response)
+    }
+
+    override fun handleTypeMismatch(
+        ex: TypeMismatchException,
+        headers: HttpHeaders,
+        status: HttpStatusCode,
+        request: WebRequest
+    ): ResponseEntity<Any>? {
+        val response = ErrorResponse(DATE_FORMAT_INVALID.name, DATE_FORMAT_INVALID.message)
         return ResponseEntity.status(BAD_REQUEST).body(response)
     }
 

--- a/src/main/kotlin/com/alloon/alloonserver/common/exception/CustomExceptionHandler.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/common/exception/CustomExceptionHandler.kt
@@ -1,6 +1,5 @@
 package com.alloon.alloonserver.common.exception
 
-import com.alloon.alloonserver.common.constant.ExceptionCode
 import com.alloon.alloonserver.common.constant.ExceptionCode.*
 import com.alloon.alloonserver.common.response.CustomException
 import com.alloon.alloonserver.common.response.ErrorResponse
@@ -17,11 +16,8 @@ import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
 import org.springframework.web.context.request.WebRequest
-import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException
 import org.springframework.web.multipart.MaxUploadSizeExceededException
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler
-import java.time.format.DateTimeParseException
-
 
 @RestControllerAdvice
 class CustomExceptionHandler : ResponseEntityExceptionHandler() {

--- a/src/main/kotlin/com/alloon/alloonserver/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/config/SecurityConfig.kt
@@ -39,6 +39,7 @@ class SecurityConfig(
                     "/api/users/challenge-history",
                     "/api/users/feeds",
                     "/api/users/challenges",
+                    "/api/users/feeds/date",
                     "/api/challenges/{challengeId}/info",
                     "/api/challenges/{challengeId}/challenge-members/goal",
                     "/api/challenges/{challengeId}/challenge-members",

--- a/src/main/kotlin/com/alloon/alloonserver/domain/user/custom/UserCustomRepository.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/domain/user/custom/UserCustomRepository.kt
@@ -2,8 +2,10 @@ package com.alloon.alloonserver.domain.user.custom
 
 import com.alloon.alloonserver.domain.user.User
 import com.alloon.alloonserver.service.user.dto.FindUserChallengeCntDto
+import com.alloon.alloonserver.service.user.dto.FindUserFeedsByDateDto
 import com.alloon.alloonserver.service.user.dto.UserChallengeHistoryDto
 import com.alloon.alloonserver.service.user.dto.UserInfoDto
+import java.time.LocalDate
 
 interface UserCustomRepository {
 
@@ -18,4 +20,6 @@ interface UserCustomRepository {
     fun findFeedsById(userId: Long): List<String>?
 
     fun findChallengeCntById(userId: Long): FindUserChallengeCntDto?
+
+    fun findFeedsByDate(userId: Long, date: LocalDate): List<FindUserFeedsByDateDto>
 }

--- a/src/main/kotlin/com/alloon/alloonserver/domain/user/custom/UserCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/domain/user/custom/UserCustomRepositoryImpl.kt
@@ -127,6 +127,7 @@ class UserCustomRepositoryImpl(
                 feed.createDateTime.month().eq(date.monthValue),
                 feed.createDateTime.dayOfMonth().eq(date.dayOfMonth)
             )
+            .orderBy(feed.challenge.proveTime.asc())
             .fetch()
     }
 

--- a/src/main/kotlin/com/alloon/alloonserver/domain/user/custom/UserCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/domain/user/custom/UserCustomRepositoryImpl.kt
@@ -11,6 +11,7 @@ import com.querydsl.core.types.dsl.BooleanExpression
 import com.querydsl.core.types.dsl.Expressions
 import com.querydsl.jpa.impl.JPAQueryFactory
 import org.springframework.stereotype.Repository
+import java.time.LocalDate
 
 @Repository
 class UserCustomRepositoryImpl(
@@ -105,6 +106,28 @@ class UserCustomRepositoryImpl(
             .from(user)
             .where(user.id.eq(userId))
             .fetchOne()
+    }
+
+    override fun findFeedsByDate(userId: Long, date: LocalDate): List<FindUserFeedsByDateDto> {
+        return queryFactory
+            .select(
+                QFindUserFeedsByDateDto(
+                    feed.id,
+                    feed.imageUrl,
+                    feed.challenge.name,
+                    feed.challenge.proveTime
+                )
+            )
+            .from(feed)
+            .join(feed.challenge)
+            .join(feed.challengeMember.user)
+            .where(
+                feed.challengeMember.user.id.eq(userId),
+                feed.createDateTime.year().eq(date.year),
+                feed.createDateTime.month().eq(date.monthValue),
+                feed.createDateTime.dayOfMonth().eq(date.dayOfMonth)
+            )
+            .fetch()
     }
 
     private fun eqUserId(userId: Long?): BooleanExpression? = userId?.let { user.id.eq(it) }

--- a/src/main/kotlin/com/alloon/alloonserver/service/user/UserService.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/service/user/UserService.kt
@@ -6,11 +6,13 @@ import com.alloon.alloonserver.domain.user.UserRepository
 import com.alloon.alloonserver.service.s3.FolderType.USERS
 import com.alloon.alloonserver.service.s3.S3Service
 import com.alloon.alloonserver.service.user.dto.FindUserChallengeCntDto
+import com.alloon.alloonserver.service.user.dto.FindUserFeedsByDateDto
 import com.alloon.alloonserver.service.user.dto.UserChallengeHistoryDto
 import com.alloon.alloonserver.service.user.dto.UserInfoDto
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.multipart.MultipartFile
+import java.time.LocalDate
 
 @Service
 @Transactional(readOnly = true)
@@ -50,6 +52,10 @@ class UserService(
 
     fun findUserChallengeCnt(userId: Long): FindUserChallengeCntDto {
         return userRepository.findChallengeCntById(userId) ?: throw CustomException(USER_NOT_FOUND)
+    }
+
+    fun findUserFeedsByDate(userId: Long, date: LocalDate): List<FindUserFeedsByDateDto> {
+        return userRepository.findFeedsByDate(userId, date)
     }
 
     private fun deleteOriginalImage(imageUrl: String) {

--- a/src/main/kotlin/com/alloon/alloonserver/service/user/dto/FindUserFeedsByDateDto.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/service/user/dto/FindUserFeedsByDateDto.kt
@@ -1,0 +1,11 @@
+package com.alloon.alloonserver.service.user.dto
+
+import com.querydsl.core.annotations.QueryProjection
+import java.time.LocalTime
+
+data class FindUserFeedsByDateDto @QueryProjection constructor(
+    val id: Long,
+    val imageUrl: String,
+    val name: String,
+    val proveTime: LocalTime,
+)

--- a/src/test/kotlin/com/alloon/alloonserver/api/controller/user/UserControllerTest.kt
+++ b/src/test/kotlin/com/alloon/alloonserver/api/controller/user/UserControllerTest.kt
@@ -3,6 +3,7 @@ package com.alloon.alloonserver.api.controller.user
 import com.alloon.alloonserver.api.controller.RestDocsSupport
 import com.alloon.alloonserver.service.user.UserService
 import com.alloon.alloonserver.service.user.dto.FindUserChallengeCntDto
+import com.alloon.alloonserver.service.user.dto.FindUserFeedsByDateDto
 import com.alloon.alloonserver.service.user.dto.UserChallengeHistoryDto
 import com.alloon.alloonserver.service.user.dto.UserInfoDto
 import io.mockk.every
@@ -12,8 +13,10 @@ import org.junit.jupiter.api.Test
 import org.springframework.http.HttpHeaders.AUTHORIZATION
 import org.springframework.http.MediaType.MULTIPART_FORM_DATA
 import org.springframework.mock.web.MockMultipartFile
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.time.LocalTime
 
 class UserControllerTest : RestDocsSupport() {
 
@@ -121,11 +124,40 @@ class UserControllerTest : RestDocsSupport() {
         resultActions.andExpect(status().isOk)
     }
 
+    @DisplayName("사용자 피드 인증 개별 날짜 조회를 성공하면 200을 반환한다.")
+    @Test
+    fun givenValid_whenFindUserFeedsByDate_thenReturn200() {
+        // given
+        val userFeeds = listOf(getFindUserFeedsByDateDto())
+
+        every { userService.findUserFeedsByDate(any(), any()) } returns userFeeds
+
+        // when
+        val resultActions = mockMvc.perform(
+            get("/api/users/feeds/date")
+                .header(AUTHORIZATION, "Bearer access-token")
+                .principal(mockPrincipal)
+                .param("date", "2024-10-23")
+        )
+
+        // then
+        resultActions.andExpect(status().isOk)
+    }
+
     private fun getUserInfoDto(): UserInfoDto {
         return UserInfoDto("https://url.kr/5MhHhD", "tester", "tester@photi.com")
     }
 
     private fun getUserChallengeHistoryDto(): UserChallengeHistoryDto {
         return UserChallengeHistoryDto("tester", "https://url.kr/5MhHhD", 99, 2)
+    }
+
+    private fun getFindUserFeedsByDateDto(): FindUserFeedsByDateDto {
+        return FindUserFeedsByDateDto(
+            1L,
+            "https://url.kr/5MhHhD",
+            "챌린지 이름",
+            LocalTime.of(13, 0)
+        )
     }
 }

--- a/src/test/kotlin/com/alloon/alloonserver/service/user/UserServiceTest.kt
+++ b/src/test/kotlin/com/alloon/alloonserver/service/user/UserServiceTest.kt
@@ -8,6 +8,7 @@ import com.alloon.alloonserver.domain.user.UserRepository
 import com.alloon.alloonserver.framework.TestContainerInitializer
 import com.alloon.alloonserver.service.s3.S3Service
 import com.alloon.alloonserver.service.user.dto.FindUserChallengeCntDto
+import com.alloon.alloonserver.service.user.dto.FindUserFeedsByDateDto
 import com.alloon.alloonserver.service.user.dto.UserChallengeHistoryDto
 import com.alloon.alloonserver.service.user.dto.UserInfoDto
 import io.mockk.Runs
@@ -22,6 +23,8 @@ import org.springframework.mock.web.MockMultipartFile
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.ContextConfiguration
 import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
+import java.time.LocalTime
 import java.util.*
 
 @ActiveProfiles("test")
@@ -196,6 +199,24 @@ class UserServiceTest {
             .isEqualTo(USER_NOT_FOUND)
     }
 
+    @DisplayName("사용자 피드 인증 개별 날짜 조회를 하면 일치하는 날짜의 인증 피드 리스트를 반환한다.")
+    @Test
+    fun givenValid_whenFindUserFeedsByDate_thenReturn() {
+        // given
+        val userId = 1L
+        val date = LocalDate.now()
+        val dto = getFindUserFeedsByDateDto()
+        val userFeeds = listOf(dto, dto, dto)
+
+        every { userRepository.findFeedsByDate(any(), any()) } returns userFeeds
+
+        // when
+        val result = userService.findUserFeedsByDate(userId, date)
+
+        // then
+        assertThat(result.size).isEqualTo(3)
+    }
+
     private fun getUser(): User {
         val contact = Contact(1L, "tester@photi.com", "000000", true)
         return User(1L, contact, "tester", "password1!", "")
@@ -211,5 +232,14 @@ class UserServiceTest {
 
     private fun getUserChallengeHistoryDto(): UserChallengeHistoryDto {
         return UserChallengeHistoryDto("tester", "https://url.kr/5MhHhD", 99, 2)
+    }
+
+    private fun getFindUserFeedsByDateDto(): FindUserFeedsByDateDto {
+        return FindUserFeedsByDateDto(
+            1L,
+            "https://url.kr/5MhHhD",
+            "챌린지 이름",
+            LocalTime.of(13, 0)
+        )
     }
 }


### PR DESCRIPTION
## 📋 이슈 번호
- close #150 
  </br>

## 🛠 구현 사항
- 인증 날짜를 RequestParam 으로 받고, 해당 날짜에 인증한 피드 리스트 조회
- 인증 시간 빠른순으로 정렬
- 인증 날짜 형식 예외 처리
  </br>

## 📚 기타
- 
  </br>