### PR TITLE
[feat] 인증 횟수 모아보기 조회 API

### DIFF
--- a/src/main/kotlin/com/alloon/alloonserver/api/controller/user/UserController.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/api/controller/user/UserController.kt
@@ -97,10 +97,11 @@ class UserController(
         return ResponseEntity.ok(response)
     }
 
-    @GetMapping("/feeds/date")
+    @GetMapping("/feeds-by-date")
     @Operation(
         summary = "사용자 피드 인증 개별 날짜 조회",
-        security = [SecurityRequirement(name = ACCESS_TOKEN_KEY)]
+        security = [SecurityRequirement(name = ACCESS_TOKEN_KEY)],
+        description = "챌린지 인증 시간 빠른순으로 정렬되어 조회됩니다."
     )
     @ApiResponse(responseCode = "200")
     @ApiErrorResponses([TOKEN_UNAUTHENTICATED, TOKEN_UNAUTHORIZED, DATE_FORMAT_INVALID])
@@ -117,7 +118,8 @@ class UserController(
     @GetMapping("/feed-history")
     @Operation(
         summary = "사용자 피드 인증 횟수 모아보기 조회",
-        security = [SecurityRequirement(name = ACCESS_TOKEN_KEY)]
+        security = [SecurityRequirement(name = ACCESS_TOKEN_KEY)],
+        description = "피드 인증 날짜 최신순으로 정렬되어 조회됩니다."
     )
     @ApiResponse(responseCode = "200")
     @ApiErrorResponses([TOKEN_UNAUTHENTICATED, TOKEN_UNAUTHORIZED])

--- a/src/main/kotlin/com/alloon/alloonserver/api/controller/user/UserController.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/api/controller/user/UserController.kt
@@ -1,12 +1,10 @@
 package com.alloon.alloonserver.api.controller.user
 
-import com.alloon.alloonserver.api.controller.user.response.FindUserChallengeCntResponse
-import com.alloon.alloonserver.api.controller.user.response.FindUserFeedsByDateResponse
-import com.alloon.alloonserver.api.controller.user.response.UserChallengeHistoryResponse
-import com.alloon.alloonserver.api.controller.user.response.UserInfoResponse
+import com.alloon.alloonserver.api.controller.user.response.*
 import com.alloon.alloonserver.common.constant.ExceptionCode.*
 import com.alloon.alloonserver.common.response.ApiErrorResponses
 import com.alloon.alloonserver.common.response.CollectionSuccessResponse
+import com.alloon.alloonserver.common.response.SliceResponse
 import com.alloon.alloonserver.common.util.UserUtility
 import com.alloon.alloonserver.config.SwaggerConfig.Companion.ACCESS_TOKEN_KEY
 import com.alloon.alloonserver.service.user.UserService
@@ -15,6 +13,7 @@ import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.data.domain.PageRequest
 import org.springframework.http.MediaType.MULTIPART_FORM_DATA_VALUE
 import org.springframework.http.ResponseEntity
 import org.springframework.validation.annotation.Validated
@@ -111,6 +110,25 @@ class UserController(
     ): ResponseEntity<List<FindUserFeedsByDateResponse>> {
         val userFeeds = userService.findUserFeedsByDate(UserUtility.getUserId(principal), date)
         val response = FindUserFeedsByDateResponse.of(userFeeds)
+
+        return ResponseEntity.ok(response)
+    }
+
+    @GetMapping("/feed-history")
+    @Operation(
+        summary = "사용자 피드 인증 횟수 모아보기 조회",
+        security = [SecurityRequirement(name = ACCESS_TOKEN_KEY)]
+    )
+    @ApiResponse(responseCode = "200")
+    @ApiErrorResponses([TOKEN_UNAUTHENTICATED, TOKEN_UNAUTHORIZED])
+    fun findUserFeedHistory(
+        principal: Principal,
+        @Parameter(description = "페이지 시작 번호") @RequestParam(defaultValue = "0") page: Int,
+        @Parameter(description = "한 페이지당 content 최대 갯수") @RequestParam(defaultValue = "10") size: Int,
+    ): ResponseEntity<SliceResponse<FindUserFeedHistoryResponse>> {
+        val pageable = PageRequest.of(page, size)
+        val userFeeds = userService.findUserFeedHistory(UserUtility.getUserId(principal), pageable)
+        val response = SliceResponse.of(userFeeds)
 
         return ResponseEntity.ok(response)
     }

--- a/src/main/kotlin/com/alloon/alloonserver/api/controller/user/response/FindUserFeedHistoryResponse.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/api/controller/user/response/FindUserFeedHistoryResponse.kt
@@ -1,0 +1,33 @@
+package com.alloon.alloonserver.api.controller.user.response
+
+import com.alloon.alloonserver.service.user.dto.FindUserFeedHistoryDto
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDate
+
+data class FindUserFeedHistoryResponse(
+
+    @Schema(description = "피드 id", example = "1")
+    val id: Long,
+
+    @Schema(description = "피드 이미지", example = "https://url.kr/5MhHhD")
+    val imageUrl: String,
+
+    @Schema(description = "피드 인증 날짜", example = "2024-10-23")
+    val createdDate: LocalDate,
+
+    @Schema(description = "챌린지 이름", example = "신나게 하는 러닝 챌린지")
+    val name: String,
+) {
+
+    companion object {
+
+        fun of(feedHistory: FindUserFeedHistoryDto): FindUserFeedHistoryResponse {
+            return FindUserFeedHistoryResponse(
+                feedHistory.id,
+                feedHistory.imageUrl,
+                feedHistory.createdDate.toLocalDate(),
+                feedHistory.name
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/alloon/alloonserver/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/config/SecurityConfig.kt
@@ -39,7 +39,7 @@ class SecurityConfig(
                     "/api/users/challenge-history",
                     "/api/users/feeds",
                     "/api/users/challenges",
-                    "/api/users/feeds/date",
+                    "/api/users/feeds-by-date",
                     "/api/users/feed-history",
                     "/api/challenges/{challengeId}/info",
                     "/api/challenges/{challengeId}/challenge-members/goal",

--- a/src/main/kotlin/com/alloon/alloonserver/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/config/SecurityConfig.kt
@@ -40,6 +40,7 @@ class SecurityConfig(
                     "/api/users/feeds",
                     "/api/users/challenges",
                     "/api/users/feeds/date",
+                    "/api/users/feed-history",
                     "/api/challenges/{challengeId}/info",
                     "/api/challenges/{challengeId}/challenge-members/goal",
                     "/api/challenges/{challengeId}/challenge-members",

--- a/src/main/kotlin/com/alloon/alloonserver/domain/user/custom/UserCustomRepository.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/domain/user/custom/UserCustomRepository.kt
@@ -1,10 +1,9 @@
 package com.alloon.alloonserver.domain.user.custom
 
 import com.alloon.alloonserver.domain.user.User
-import com.alloon.alloonserver.service.user.dto.FindUserChallengeCntDto
-import com.alloon.alloonserver.service.user.dto.FindUserFeedsByDateDto
-import com.alloon.alloonserver.service.user.dto.UserChallengeHistoryDto
-import com.alloon.alloonserver.service.user.dto.UserInfoDto
+import com.alloon.alloonserver.service.user.dto.*
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
 import java.time.LocalDate
 
 interface UserCustomRepository {
@@ -22,4 +21,6 @@ interface UserCustomRepository {
     fun findChallengeCntById(userId: Long): FindUserChallengeCntDto?
 
     fun findFeedsByDate(userId: Long, date: LocalDate): List<FindUserFeedsByDateDto>
+
+    fun findFeedHistoryById(userId: Long, pageable: Pageable): Slice<FindUserFeedHistoryDto>
 }

--- a/src/main/kotlin/com/alloon/alloonserver/domain/user/custom/UserCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/domain/user/custom/UserCustomRepositoryImpl.kt
@@ -10,6 +10,9 @@ import com.alloon.alloonserver.service.user.dto.*
 import com.querydsl.core.types.dsl.BooleanExpression
 import com.querydsl.core.types.dsl.Expressions
 import com.querydsl.jpa.impl.JPAQueryFactory
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
+import org.springframework.data.domain.SliceImpl
 import org.springframework.stereotype.Repository
 import java.time.LocalDate
 
@@ -129,6 +132,39 @@ class UserCustomRepositoryImpl(
             )
             .orderBy(feed.challenge.proveTime.asc())
             .fetch()
+    }
+
+    override fun findFeedHistoryById(
+        userId: Long,
+        pageable: Pageable
+    ): Slice<FindUserFeedHistoryDto> {
+        val pageSize = pageable.pageSize
+        val content = queryFactory
+            .select(
+                QFindUserFeedHistoryDto(
+                    feed.id,
+                    feed.imageUrl,
+                    feed.createDateTime,
+                    feed.challenge.name
+                )
+            )
+            .from(feed)
+            .join(feed.challenge)
+            .join(feed.challengeMember.user)
+            .where(feed.challengeMember.user.id.eq(userId))
+            .orderBy(feed.createDateTime.desc())
+            .offset(pageable.offset)
+            .limit(pageSize + 1L)
+            .fetch()
+
+        val hasNext = if (content.size > pageSize) {
+            content.removeAt(pageSize)
+            true
+        } else {
+            false
+        }
+
+        return SliceImpl(content, pageable, hasNext)
     }
 
     private fun eqUserId(userId: Long?): BooleanExpression? = userId?.let { user.id.eq(it) }

--- a/src/main/kotlin/com/alloon/alloonserver/service/user/UserService.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/service/user/UserService.kt
@@ -1,5 +1,6 @@
 package com.alloon.alloonserver.service.user
 
+import com.alloon.alloonserver.api.controller.user.response.FindUserFeedHistoryResponse
 import com.alloon.alloonserver.common.constant.ExceptionCode.USER_NOT_FOUND
 import com.alloon.alloonserver.common.response.CustomException
 import com.alloon.alloonserver.domain.user.UserRepository
@@ -9,6 +10,8 @@ import com.alloon.alloonserver.service.user.dto.FindUserChallengeCntDto
 import com.alloon.alloonserver.service.user.dto.FindUserFeedsByDateDto
 import com.alloon.alloonserver.service.user.dto.UserChallengeHistoryDto
 import com.alloon.alloonserver.service.user.dto.UserInfoDto
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.multipart.MultipartFile
@@ -56,6 +59,11 @@ class UserService(
 
     fun findUserFeedsByDate(userId: Long, date: LocalDate): List<FindUserFeedsByDateDto> {
         return userRepository.findFeedsByDate(userId, date)
+    }
+
+    fun findUserFeedHistory(userId: Long, pageable: Pageable): Slice<FindUserFeedHistoryResponse> {
+        return userRepository.findFeedHistoryById(userId, pageable)
+            .map { FindUserFeedHistoryResponse.of(it) }
     }
 
     private fun deleteOriginalImage(imageUrl: String) {

--- a/src/main/kotlin/com/alloon/alloonserver/service/user/dto/FindUserFeedHistoryDto.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/service/user/dto/FindUserFeedHistoryDto.kt
@@ -1,0 +1,11 @@
+package com.alloon.alloonserver.service.user.dto
+
+import com.querydsl.core.annotations.QueryProjection
+import java.time.LocalDateTime
+
+data class FindUserFeedHistoryDto @QueryProjection constructor(
+    val id: Long,
+    val imageUrl: String,
+    val createdDate: LocalDateTime,
+    val name: String,
+)

--- a/src/test/kotlin/com/alloon/alloonserver/api/controller/user/UserControllerTest.kt
+++ b/src/test/kotlin/com/alloon/alloonserver/api/controller/user/UserControllerTest.kt
@@ -1,21 +1,23 @@
 package com.alloon.alloonserver.api.controller.user
 
 import com.alloon.alloonserver.api.controller.RestDocsSupport
+import com.alloon.alloonserver.api.controller.challenge.response.FindChallengesResponse
+import com.alloon.alloonserver.api.controller.user.response.FindUserFeedHistoryResponse
 import com.alloon.alloonserver.service.user.UserService
-import com.alloon.alloonserver.service.user.dto.FindUserChallengeCntDto
-import com.alloon.alloonserver.service.user.dto.FindUserFeedsByDateDto
-import com.alloon.alloonserver.service.user.dto.UserChallengeHistoryDto
-import com.alloon.alloonserver.service.user.dto.UserInfoDto
+import com.alloon.alloonserver.service.user.dto.*
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.SliceImpl
 import org.springframework.http.HttpHeaders.AUTHORIZATION
 import org.springframework.http.MediaType.MULTIPART_FORM_DATA
 import org.springframework.mock.web.MockMultipartFile
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.time.LocalDateTime
 import java.time.LocalTime
 
 class UserControllerTest : RestDocsSupport() {
@@ -138,6 +140,32 @@ class UserControllerTest : RestDocsSupport() {
                 .header(AUTHORIZATION, "Bearer access-token")
                 .principal(mockPrincipal)
                 .param("date", "2024-10-23")
+        )
+
+        // then
+        resultActions.andExpect(status().isOk)
+    }
+
+    @DisplayName("사용자 피드 인증 횟수 모아보기 조회를 성공하면 200을 반환한다.")
+    @Test
+    fun givenValid_whenFindUserFeedHistory_thenReturn200() {
+        // given
+        val dto = FindUserFeedHistoryDto(1L, "https://url.kr/5MhHhD", LocalDateTime.now(), "챌린지 이름")
+        val content = listOf(FindUserFeedHistoryResponse.of(dto))
+        val pageable = PageRequest.of(0, 10)
+        val hasNext = true
+
+        every { userService.findUserFeedHistory(any(), any()) } returns SliceImpl(
+            content,
+            pageable,
+            hasNext
+        )
+
+        // when
+        val resultActions = mockMvc.perform(
+            get("/api/users/feed-history")
+                .header(AUTHORIZATION, "Bearer access-token")
+                .principal(mockPrincipal)
         )
 
         // then

--- a/src/test/kotlin/com/alloon/alloonserver/api/controller/user/UserControllerTest.kt
+++ b/src/test/kotlin/com/alloon/alloonserver/api/controller/user/UserControllerTest.kt
@@ -136,7 +136,7 @@ class UserControllerTest : RestDocsSupport() {
 
         // when
         val resultActions = mockMvc.perform(
-            get("/api/users/feeds/date")
+            get("/api/users/feeds-by-date")
                 .header(AUTHORIZATION, "Bearer access-token")
                 .principal(mockPrincipal)
                 .param("date", "2024-10-23")

--- a/src/test/kotlin/com/alloon/alloonserver/service/user/UserServiceTest.kt
+++ b/src/test/kotlin/com/alloon/alloonserver/service/user/UserServiceTest.kt
@@ -7,10 +7,7 @@ import com.alloon.alloonserver.domain.user.User
 import com.alloon.alloonserver.domain.user.UserRepository
 import com.alloon.alloonserver.framework.TestContainerInitializer
 import com.alloon.alloonserver.service.s3.S3Service
-import com.alloon.alloonserver.service.user.dto.FindUserChallengeCntDto
-import com.alloon.alloonserver.service.user.dto.FindUserFeedsByDateDto
-import com.alloon.alloonserver.service.user.dto.UserChallengeHistoryDto
-import com.alloon.alloonserver.service.user.dto.UserInfoDto
+import com.alloon.alloonserver.service.user.dto.*
 import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
@@ -19,11 +16,14 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.SliceImpl
 import org.springframework.mock.web.MockMultipartFile
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.ContextConfiguration
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
+import java.time.LocalDateTime
 import java.time.LocalTime
 import java.util.*
 
@@ -215,6 +215,29 @@ class UserServiceTest {
 
         // then
         assertThat(result.size).isEqualTo(3)
+    }
+
+    @DisplayName("사용자 피드 인증 횟수 모아보기 조회를 하면 페이징 객체를 반환한다.")
+    @Test
+    fun givenValid_whenFindUserFeedHistory_thenReturn() {
+        // given
+        val userId = 1L
+        val dto = FindUserFeedHistoryDto(1L, "https://url.kr/5MhHhD", LocalDateTime.now(), "챌린지 이름")
+        val content = listOf(dto, dto, dto)
+        val pageable = PageRequest.of(0, 10)
+        val hasNext = true
+
+        every { userRepository.findFeedHistoryById(any(), any()) } returns SliceImpl(
+            content,
+            pageable,
+            hasNext
+        )
+
+        // when
+        val result = userService.findUserFeedHistory(userId, pageable)
+
+        // then
+        assertThat(result.content.size).isEqualTo(3)
     }
 
     private fun getUser(): User {


### PR DESCRIPTION
## 📋 이슈 번호
- close #151 
  </br>

## 🛠 구현 사항
- 피드 이미지, 피드 인증 날짜, 피드 id, 챌린지 이름 조회
- 페이징 처리
- 피드 인증 날짜 최신순으로 정렬
  </br>

## 📚 기타
- 
  </br>