### PR TITLE
[feat] 피드 댓글 목록 조회 API

### DIFF
--- a/src/main/kotlin/com/alloon/alloonserver/api/controller/challenge/ChallengeController.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/api/controller/challenge/ChallengeController.kt
@@ -296,4 +296,25 @@ class ChallengeController(
 
         return ResponseEntity.ok(response)
     }
+
+    @GetMapping("/feeds/{feedId}/comments")
+    @Operation(
+        summary = "챌린지 피드 댓글 리스트 조회",
+        security = [SecurityRequirement(name = ACCESS_TOKEN_KEY)],
+        description = "댓글 작성 오래된 순으로 정렬되어 조회됩니다."
+    )
+    @ApiResponse(responseCode = "200")
+    @ApiErrorResponses([TOKEN_UNAUTHENTICATED, TOKEN_UNAUTHORIZED])
+    fun findChallengeFeedComments(
+        principal: Principal,
+        @PathVariable @Parameter(description = "피드 id", example = "1") feedId: Long,
+        @Parameter(description = "페이지 시작 번호") @RequestParam(defaultValue = "0") page: Int,
+        @Parameter(description = "한 페이지당 content 최대 갯수") @RequestParam(defaultValue = "10") size: Int,
+    ): ResponseEntity<SliceResponse<FindChallengeFeedCommentsResponse>> {
+        val pageable = PageRequest.of(page, size)
+        val feedComments = challengeService.findChallengeFeedComments(feedId, pageable)
+        val response = SliceResponse.of(feedComments)
+
+        return ResponseEntity.ok(response)
+    }
 }

--- a/src/main/kotlin/com/alloon/alloonserver/api/controller/challenge/response/FindChallengeFeedCommentsResponse.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/api/controller/challenge/response/FindChallengeFeedCommentsResponse.kt
@@ -1,0 +1,28 @@
+package com.alloon.alloonserver.api.controller.challenge.response
+
+import com.alloon.alloonserver.service.challenge.dto.FindChallengeFeedCommentsDto
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class FindChallengeFeedCommentsResponse(
+
+    @Schema(description = "댓글 id", example = "1")
+    val id: Long,
+
+    @Schema(description = "댓글 작성자 아이디", example = "photi")
+    val username: String,
+
+    @Schema(description = "댓글 내용", example = "멋져요")
+    val comment: String,
+) {
+
+    companion object {
+
+        fun of(comments: FindChallengeFeedCommentsDto): FindChallengeFeedCommentsResponse {
+            return FindChallengeFeedCommentsResponse(
+                comments.id,
+                comments.username,
+                comments.comment
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/alloon/alloonserver/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/config/SecurityConfig.kt
@@ -47,6 +47,7 @@ class SecurityConfig(
                     "/api/challenges/{challengeId}/feeds",
                     "/api/challenges/{challengeId}/feeds/{feedId}",
                     "/api/challenges/{challengeId}/feeds/{feedId}/comments",
+                    "/api/challenges/feeds/{feedId}/comments",
                 ).authenticated()
                 it.anyRequest().permitAll()
             }

--- a/src/main/kotlin/com/alloon/alloonserver/domain/feed/custom/FeedCommentCustomRepository.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/domain/feed/custom/FeedCommentCustomRepository.kt
@@ -1,8 +1,13 @@
 package com.alloon.alloonserver.domain.feed.custom
 
 import com.alloon.alloonserver.domain.feed.FeedComment
+import com.alloon.alloonserver.service.challenge.dto.FindChallengeFeedCommentsDto
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
 
 interface FeedCommentCustomRepository {
 
     fun findByCommentId(commentId: Long): FeedComment?
+
+    fun findAllByFeedId(feedId: Long, pageable: Pageable): Slice<FindChallengeFeedCommentsDto>
 }

--- a/src/main/kotlin/com/alloon/alloonserver/domain/feed/custom/FeedCommentCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/domain/feed/custom/FeedCommentCustomRepositoryImpl.kt
@@ -2,7 +2,12 @@ package com.alloon.alloonserver.domain.feed.custom
 
 import com.alloon.alloonserver.domain.feed.FeedComment
 import com.alloon.alloonserver.domain.feed.QFeedComment.feedComment
+import com.alloon.alloonserver.service.challenge.dto.FindChallengeFeedCommentsDto
+import com.alloon.alloonserver.service.challenge.dto.QFindChallengeFeedCommentsDto
 import com.querydsl.jpa.impl.JPAQueryFactory
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
+import org.springframework.data.domain.SliceImpl
 import org.springframework.stereotype.Repository
 
 @Repository
@@ -17,5 +22,37 @@ class FeedCommentCustomRepositoryImpl(
             .join(feedComment.challengeMember).fetchJoin()
             .where(feedComment.id.eq(commentId))
             .fetchFirst()
+    }
+
+    override fun findAllByFeedId(
+        feedId: Long,
+        pageable: Pageable
+    ): Slice<FindChallengeFeedCommentsDto> {
+        val pageSize = pageable.pageSize
+        val content = queryFactory
+            .select(
+                QFindChallengeFeedCommentsDto(
+                    feedComment.id,
+                    feedComment.challengeMember.user.username,
+                    feedComment.comment,
+                )
+            )
+            .from(feedComment)
+            .join(feedComment.feed)
+            .join(feedComment.challengeMember.user)
+            .where(feedComment.feed.id.eq(feedId))
+            .orderBy(feedComment.createDateTime.asc())
+            .offset(pageable.offset)
+            .limit(pageSize + 1L)
+            .fetch()
+
+        val hasNext = if (content.size > pageSize) {
+            content.removeAt(pageSize)
+            true
+        } else {
+            false
+        }
+
+        return SliceImpl(content, pageable, hasNext)
     }
 }

--- a/src/main/kotlin/com/alloon/alloonserver/service/challenge/ChallengeService.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/service/challenge/ChallengeService.kt
@@ -1,5 +1,6 @@
 package com.alloon.alloonserver.service.challenge
 
+import com.alloon.alloonserver.api.controller.challenge.response.FindChallengeFeedCommentsResponse
 import com.alloon.alloonserver.api.controller.challenge.response.FindChallengeFeedsByDateResponse
 import com.alloon.alloonserver.api.controller.challenge.response.FindChallengesResponse
 import com.alloon.alloonserver.common.constant.ExceptionCode.*
@@ -204,6 +205,14 @@ class ChallengeService(
         validateChallenge(challengeId)
         validateChallengeMember(userId, challengeId)
         return feedRepository.findContentById(feedId) ?: throw CustomException(FEED_NOT_FOUND)
+    }
+
+    fun findChallengeFeedComments(
+        feedId: Long,
+        pageable: Pageable
+    ): Slice<FindChallengeFeedCommentsResponse> {
+        return feedCommentRepository.findAllByFeedId(feedId, pageable)
+            .map { FindChallengeFeedCommentsResponse.of(it) }
     }
 
     private fun validateUser(userId: Long): User {

--- a/src/main/kotlin/com/alloon/alloonserver/service/challenge/dto/FindChallengeFeedCommentsDto.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/service/challenge/dto/FindChallengeFeedCommentsDto.kt
@@ -1,0 +1,9 @@
+package com.alloon.alloonserver.service.challenge.dto
+
+import com.querydsl.core.annotations.QueryProjection
+
+data class FindChallengeFeedCommentsDto @QueryProjection constructor(
+    val id: Long,
+    val username: String,
+    val comment: String,
+)

--- a/src/test/kotlin/com/alloon/alloonserver/api/controller/challenge/ChallengeControllerTest.kt
+++ b/src/test/kotlin/com/alloon/alloonserver/api/controller/challenge/ChallengeControllerTest.kt
@@ -2,6 +2,7 @@ package com.alloon.alloonserver.api.controller.challenge
 
 import com.alloon.alloonserver.api.controller.RestDocsSupport
 import com.alloon.alloonserver.api.controller.challenge.request.*
+import com.alloon.alloonserver.api.controller.challenge.response.FindChallengeFeedCommentsResponse
 import com.alloon.alloonserver.api.controller.challenge.response.FindChallengeFeedsByDateResponse
 import com.alloon.alloonserver.api.controller.challenge.response.FindChallengesResponse
 import com.alloon.alloonserver.service.challenge.ChallengeService
@@ -366,6 +367,33 @@ class ChallengeControllerTest : RestDocsSupport() {
         // when
         val resultActions = mockMvc.perform(
             get("/api/challenges/{challengeId}/feeds/{feedId}", 1, 1)
+                .header(AUTHORIZATION, "Bearer access-token")
+                .principal(mockPrincipal)
+                .contentType(APPLICATION_JSON)
+        )
+
+        // then
+        resultActions.andExpect(status().isOk)
+    }
+
+    @DisplayName("챌린지 피드 댓글 리스트 조회를 성공하면 200을 반환한다")
+    @Test
+    fun givenValid_whenFindChallengeFeedComments_thenReturn200() {
+        // given
+        val dto = FindChallengeFeedCommentsDto(1L, "tester", "피드 댓글")
+        val content = listOf(FindChallengeFeedCommentsResponse.of(dto))
+        val pageable = PageRequest.of(0, 10)
+        val hasNext = true
+
+        every { challengeService.findChallengeFeedComments(any(), any()) } returns SliceImpl(
+            content,
+            pageable,
+            hasNext
+        )
+
+        // when
+        val resultActions = mockMvc.perform(
+            get("/api/challenges/feeds/{feedId}/comments", 1)
                 .header(AUTHORIZATION, "Bearer access-token")
                 .principal(mockPrincipal)
                 .contentType(APPLICATION_JSON)

--- a/src/test/kotlin/com/alloon/alloonserver/service/challenge/ChallengeServiceTest.kt
+++ b/src/test/kotlin/com/alloon/alloonserver/service/challenge/ChallengeServiceTest.kt
@@ -876,6 +876,29 @@ class ChallengeServiceTest : AbstractMailProperties {
             .isEqualTo(FEED_NOT_FOUND)
     }
 
+    @DisplayName("챌린지 피드 댓글 리스트 조회를 하면 페이징 객체를 반환한다.")
+    @Test
+    fun givenValid_whenFindChallengeFeedComments_thenReturn() {
+        // given
+        val feedId = 1L
+        val dto = FindChallengeFeedCommentsDto(1L, "tester", "피드 댓글")
+        val content = listOf(dto, dto, dto)
+        val pageable = PageRequest.of(0, 10)
+        val hasNext = true
+
+        every { feedCommentRepository.findAllByFeedId(any(), any()) } returns SliceImpl(
+            content,
+            pageable,
+            hasNext
+        )
+
+        // when
+        val result = challengeService.findChallengeFeedComments(feedId, pageable)
+
+        // then
+        assertThat(result.content.size).isEqualTo(3)
+    }
+
     private fun getUser(): User {
         val contact = Contact(1L, "tester@photi.com", "000000", true)
         return User(1L, contact, "tester", "password1!", "")


### PR DESCRIPTION
## 📋 이슈 번호
- close #142 
  </br>

## 🛠 구현 사항
- 댓글 id, 댓글 작성자, 댓글 내용 조회
- 페이징 처리
- 댓글 작성 오래된 순으로 정렬
  </br>

## 📚 기타
- 
  </br>