### PR TITLE
[feat] 챌린지 초대코드 조회 API

### DIFF
--- a/docker/init.sql
+++ b/docker/init.sql
@@ -78,7 +78,7 @@ CREATE TABLE challenge
     start_date                  DATE                      NOT NULL,
     current_member_cnt          INT                       NOT NULL,
     visit_cnt                   INT                       NOT NULL,
-    is_recruit                  BOOLEAN                   NOT NULL,
+    invitation_code             VARCHAR(5)                NOT NULL,
     create_date_time            TIMESTAMP(6)              NOT NULL,
     update_date_time            TIMESTAMP(6)              NOT NULL,
     service_status              VARCHAR(10)               NOT NULL,

--- a/src/main/kotlin/com/alloon/alloonserver/api/controller/challenge/ChallengeController.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/api/controller/challenge/ChallengeController.kt
@@ -317,4 +317,21 @@ class ChallengeController(
 
         return ResponseEntity.ok(response)
     }
+
+    @GetMapping("/{challengeId}/invitation-code")
+    @Operation(summary = "챌린지 초대코드 조회", security = [SecurityRequirement(name = ACCESS_TOKEN_KEY)])
+    @ApiResponse(responseCode = "200")
+    @ApiErrorResponses([TOKEN_UNAUTHENTICATED, TOKEN_UNAUTHORIZED, CHALLENGE_NOT_FOUND, CHALLENGE_MEMBER_NOT_FOUND])
+    fun findChallengeInvitationCode(
+        principal: Principal,
+        @PathVariable @Parameter(description = "챌린지 id", example = "1") challengeId: Long,
+    ): ResponseEntity<FindChallengeInvitationCodeResponse> {
+        val invitationCode = challengeService.findChallengeInvitationCode(
+            UserUtility.getUserId(principal),
+            challengeId
+        )
+        val response = FindChallengeInvitationCodeResponse.of(invitationCode)
+
+        return ResponseEntity.ok(response)
+    }
 }

--- a/src/main/kotlin/com/alloon/alloonserver/api/controller/challenge/response/FindChallengeInvitationCodeResponse.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/api/controller/challenge/response/FindChallengeInvitationCodeResponse.kt
@@ -1,0 +1,22 @@
+package com.alloon.alloonserver.api.controller.challenge.response
+
+import com.alloon.alloonserver.service.challenge.dto.FindChallengeInvitationCodeDto
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "챌린지 초대코드 조회 응답 객체")
+data class FindChallengeInvitationCodeResponse(
+
+    @Schema(description = "챌린지 이름", example = "신나게 하는 러닝 챌린지")
+    val name: String,
+
+    @Schema(description = "챌린지 초대코드", example = "478DS")
+    val invitationCode: String,
+) {
+
+    companion object {
+
+        fun of(challenge: FindChallengeInvitationCodeDto): FindChallengeInvitationCodeResponse {
+            return FindChallengeInvitationCodeResponse(challenge.name, challenge.invitationCode)
+        }
+    }
+}

--- a/src/main/kotlin/com/alloon/alloonserver/common/util/CodeUtility.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/common/util/CodeUtility.kt
@@ -2,7 +2,7 @@ package com.alloon.alloonserver.common.util
 
 import kotlin.random.Random
 
-class VerificationCodeUtility {
+class CodeUtility {
 
     companion object {
 
@@ -10,6 +10,13 @@ class VerificationCodeUtility {
             return (0..9).toList()
                 .shuffled(Random(System.currentTimeMillis()))
                 .take(4)
+                .joinToString("")
+        }
+
+        fun getInvitationCode(): String {
+            val range = (0..9) + ('A'..'Z')
+            return range.shuffled(Random(System.currentTimeMillis()))
+                .take(5)
                 .joinToString("")
         }
     }

--- a/src/main/kotlin/com/alloon/alloonserver/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/config/SecurityConfig.kt
@@ -42,6 +42,7 @@ class SecurityConfig(
                     "/api/users/feeds-by-date",
                     "/api/users/feed-history",
                     "/api/challenges/{challengeId}/info",
+                    "/api/challenges/{challengeId}/invitation-code",
                     "/api/challenges/{challengeId}/challenge-members/goal",
                     "/api/challenges/{challengeId}/challenge-members",
                     "/api/challenges/{challengeId}/feeds",

--- a/src/main/kotlin/com/alloon/alloonserver/domain/challenge/Challenge.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/domain/challenge/Challenge.kt
@@ -31,6 +31,9 @@ class Challenge(
     @Column(nullable = false, length = 500)
     var imageUrl: String,
 
+    @Column(length = 5)
+    val invitationCode: String,
+
     @Column(nullable = false)
     @OneToMany(mappedBy = "challenge", cascade = [CascadeType.ALL], orphanRemoval = true)
     val rules: MutableList<ChallengeRule> = mutableListOf(),
@@ -48,9 +51,6 @@ class Challenge(
     //TODO redis 사용하면 hyperlog 로 변경 필요함.
     @Column(nullable = false)
     var visitCnt: Int = 0,
-
-    @Column(nullable = false)
-    val isRecruit: Boolean = true,
 ) : BasePermanentEntity() {
 
     fun addChallengeRule(rule: ChallengeRule) {

--- a/src/main/kotlin/com/alloon/alloonserver/domain/challenge/custom/ChallengeCustomRepository.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/domain/challenge/custom/ChallengeCustomRepository.kt
@@ -1,6 +1,7 @@
 package com.alloon.alloonserver.domain.challenge.custom
 
 import com.alloon.alloonserver.domain.challenge.Challenge
+import com.alloon.alloonserver.service.challenge.dto.FindChallengeInvitationCodeDto
 import com.alloon.alloonserver.service.challenge.dto.FindChallengesDto
 import com.alloon.alloonserver.service.challenge.dto.FindPopularChallengesDto
 import org.springframework.data.domain.Pageable
@@ -15,4 +16,6 @@ interface ChallengeCustomRepository {
     fun findInfoById(id: Long): Challenge?
 
     fun findAllOrderByStartDate(pageable: Pageable): Slice<FindChallengesDto>
+
+    fun findInvitationCodeById(id: Long): FindChallengeInvitationCodeDto?
 }

--- a/src/main/kotlin/com/alloon/alloonserver/domain/challenge/custom/ChallengeCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/domain/challenge/custom/ChallengeCustomRepositoryImpl.kt
@@ -5,10 +5,7 @@ import com.alloon.alloonserver.domain.base.ServiceStatus.ACTIVE
 import com.alloon.alloonserver.domain.challenge.Challenge
 import com.alloon.alloonserver.domain.challenge.QChallenge.challenge
 import com.alloon.alloonserver.domain.challenge.QChallengeMember.challengeMember
-import com.alloon.alloonserver.service.challenge.dto.FindChallengesDto
-import com.alloon.alloonserver.service.challenge.dto.FindPopularChallengesDto
-import com.alloon.alloonserver.service.challenge.dto.QFindChallengesDto
-import com.alloon.alloonserver.service.challenge.dto.QFindPopularChallengesDto
+import com.alloon.alloonserver.service.challenge.dto.*
 import com.querydsl.core.types.dsl.BooleanExpression
 import com.querydsl.core.types.dsl.Expressions
 import com.querydsl.jpa.impl.JPAQueryFactory
@@ -100,6 +97,19 @@ class ChallengeCustomRepositoryImpl(
         }
 
         return SliceImpl(content, pageable, hasNext)
+    }
+
+    override fun findInvitationCodeById(id: Long): FindChallengeInvitationCodeDto? {
+        return queryFactory
+            .select(
+                QFindChallengeInvitationCodeDto(
+                    challenge.name,
+                    challenge.invitationCode
+                )
+            )
+            .from(challenge)
+            .where(challenge.id.eq(id))
+            .fetchOne()
     }
 
     private fun eqServiceStatus(serviceStatus: ServiceStatus?): BooleanExpression? =

--- a/src/main/kotlin/com/alloon/alloonserver/service/challenge/ChallengeService.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/service/challenge/ChallengeService.kt
@@ -217,6 +217,15 @@ class ChallengeService(
             .map { FindChallengeFeedCommentsResponse.of(it) }
     }
 
+    fun findChallengeInvitationCode(
+        userId: Long,
+        challengeId: Long
+    ): FindChallengeInvitationCodeDto {
+        validateChallengeMember(userId, challengeId)
+        return challengeRepository.findInvitationCodeById(challengeId)
+            ?: throw CustomException(CHALLENGE_NOT_FOUND)
+    }
+
     private fun validateUser(userId: Long): User {
         return userRepository.find(userId) ?: throw CustomException(USER_NOT_FOUND)
     }

--- a/src/main/kotlin/com/alloon/alloonserver/service/challenge/ChallengeService.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/service/challenge/ChallengeService.kt
@@ -6,6 +6,7 @@ import com.alloon.alloonserver.api.controller.challenge.response.FindChallengesR
 import com.alloon.alloonserver.common.constant.ExceptionCode.*
 import com.alloon.alloonserver.common.constant.SortTypeConstants
 import com.alloon.alloonserver.common.response.CustomException
+import com.alloon.alloonserver.common.util.CodeUtility
 import com.alloon.alloonserver.domain.challenge.*
 import com.alloon.alloonserver.domain.feed.Feed
 import com.alloon.alloonserver.domain.feed.FeedCommentRepository
@@ -45,8 +46,9 @@ class ChallengeService(
         val user = validateUser(userId)
         val fileName = s3Service.uploadImage(imageFile, CHALLENGES)
         val imageUrl = s3Service.getImageUrl(fileName)
+        val invitationCode = CodeUtility.getInvitationCode()
 
-        val challenge = dto.toEntity(imageUrl)
+        val challenge = dto.toEntity(imageUrl, invitationCode)
         val challengeMember = ChallengeMember(user = user, challenge = challenge)
 
         challengeRepository.save(challenge)

--- a/src/main/kotlin/com/alloon/alloonserver/service/challenge/dto/CreateChallengeDto.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/service/challenge/dto/CreateChallengeDto.kt
@@ -17,7 +17,7 @@ data class CreateChallengeDto(
     val imageUrl: String? = null,
 ) {
 
-    fun toEntity(imageUrl: String): Challenge {
+    fun toEntity(imageUrl: String, invitationCode: String): Challenge {
         val challenge = Challenge(
             name = name,
             isPublic = isPublic,
@@ -26,6 +26,7 @@ data class CreateChallengeDto(
             endDate = endDate,
             imageUrl = imageUrl,
             hashtags = hashtags.map { it.hashtag },
+            invitationCode = invitationCode,
         )
         rules.forEach {
             challenge.addChallengeRule(ChallengeRule(rule = it.rule))

--- a/src/main/kotlin/com/alloon/alloonserver/service/challenge/dto/FindChallengeInvitationCodeDto.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/service/challenge/dto/FindChallengeInvitationCodeDto.kt
@@ -1,0 +1,8 @@
+package com.alloon.alloonserver.service.challenge.dto
+
+import com.querydsl.core.annotations.QueryProjection
+
+data class FindChallengeInvitationCodeDto @QueryProjection constructor(
+    val name: String,
+    val invitationCode: String,
+)

--- a/src/main/kotlin/com/alloon/alloonserver/service/user/AuthService.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/service/user/AuthService.kt
@@ -5,7 +5,7 @@ import com.alloon.alloonserver.common.constant.ExceptionCode.*
 import com.alloon.alloonserver.common.constant.UnavailableConstants.UNAVAILABLE_USERNAMES
 import com.alloon.alloonserver.common.response.CustomException
 import com.alloon.alloonserver.common.util.PasswordUtility
-import com.alloon.alloonserver.common.util.VerificationCodeUtility
+import com.alloon.alloonserver.common.util.CodeUtility
 import com.alloon.alloonserver.domain.user.ContactRepository
 import com.alloon.alloonserver.domain.user.UserRepository
 import com.alloon.alloonserver.domain.user.UserRoleRepository
@@ -33,7 +33,7 @@ class AuthService(
 
     @Transactional
     fun sendVerificationCode(@Valid request: ContactServiceSendVerificationDto) {
-        val verificationCode = VerificationCodeUtility.getVerificationCode()
+        val verificationCode = CodeUtility.getVerificationCode()
 
         contactRepository.findByEmail(request.email)
             ?.let { foundContact ->

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -78,7 +78,7 @@ CREATE TABLE challenge
     start_date                  DATE                      NOT NULL,
     current_member_cnt          INT                       NOT NULL,
     visit_cnt                   INT                       NOT NULL,
-    is_recruit                  BOOLEAN                   NOT NULL,
+    invitation_code             VARCHAR(5)                NOT NULL,
     create_date_time            TIMESTAMP(6)              NOT NULL,
     update_date_time            TIMESTAMP(6)              NOT NULL,
     service_status              VARCHAR(10)               NOT NULL,

--- a/src/test/kotlin/com/alloon/alloonserver/api/controller/challenge/ChallengeControllerTest.kt
+++ b/src/test/kotlin/com/alloon/alloonserver/api/controller/challenge/ChallengeControllerTest.kt
@@ -403,6 +403,25 @@ class ChallengeControllerTest : RestDocsSupport() {
         resultActions.andExpect(status().isOk)
     }
 
+    @DisplayName("챌린지 초대코드 조회를 성공하면 200을 반환한다.")
+    @Test
+    fun givenValid_whenFindChallengeInvitationCode_thenReturn200() {
+        // given
+        val dto = FindChallengeInvitationCodeDto("챌린지 이름", "ABC12")
+        every { challengeService.findChallengeInvitationCode(any(), any()) } returns dto
+
+        // when
+        val resultActions = mockMvc.perform(
+            get("/api/challenges/{challengeId}/invitation-code", 1)
+                .header(AUTHORIZATION, "Bearer access-token")
+                .principal(mockPrincipal)
+                .contentType(APPLICATION_JSON)
+        )
+
+        // then
+        resultActions.andExpect(status().isOk)
+    }
+
     private fun getCreateChallengeRequest(): CreateChallengeRequest {
         return CreateChallengeRequest(
             "챌린지 이름",

--- a/src/test/kotlin/com/alloon/alloonserver/common/scheduler/ScheduledTasksTest.kt
+++ b/src/test/kotlin/com/alloon/alloonserver/common/scheduler/ScheduledTasksTest.kt
@@ -40,7 +40,7 @@ class ScheduledTasksTest(
 
     private fun createAndSaveChallenge(endDate: LocalDate): Challenge {
         val dto = getCreateChallengeDto(endDate)
-        val challenge = dto.toEntity("https://url.kr/5MhHhD")
+        val challenge = dto.toEntity("https://url.kr/5MhHhD", "ABC12")
         return challengeRepository.save(challenge)
     }
 

--- a/src/test/kotlin/com/alloon/alloonserver/common/util/CodeUtilityTest.kt
+++ b/src/test/kotlin/com/alloon/alloonserver/common/util/CodeUtilityTest.kt
@@ -1,0 +1,40 @@
+package com.alloon.alloonserver.common.util
+
+import io.mockk.every
+import io.mockk.mockkObject
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+class CodeUtilityTest {
+
+    @DisplayName("인증코드 생성이 정상 작동한다.")
+    @Test
+    fun givenValid_whenGetVerificationCode_thenReturn() {
+        // given
+        val randomCode = "3429"
+        mockkObject(CodeUtility)
+        every { CodeUtility.getVerificationCode() } returns randomCode
+
+        // when
+        val result = CodeUtility.getVerificationCode()
+
+        // then
+        assertThat(result).isEqualTo(randomCode)
+    }
+
+    @DisplayName("초대코드 생성이 정상 작동한다.")
+    @Test
+    fun givenValid_whenGetInvitationCode_thenReturn() {
+        // given
+        val randomCode = "ABC12"
+        mockkObject(CodeUtility)
+        every { CodeUtility.getInvitationCode() } returns randomCode
+
+        // when
+        val result = CodeUtility.getInvitationCode()
+
+        // then
+        assertThat(result).isEqualTo(randomCode)
+    }
+}

--- a/src/test/kotlin/com/alloon/alloonserver/domain/challenge/ChallengeMemberRepositoryTest.kt
+++ b/src/test/kotlin/com/alloon/alloonserver/domain/challenge/ChallengeMemberRepositoryTest.kt
@@ -71,7 +71,8 @@ class ChallengeMemberRepositoryTest(
 
         val contact = contactRepository.save(getContact("tester2@photi.com"))
         val user = userRepository.save(getUser(contact, "tester2"))
-        val tester2 = challenge?.let { ChallengeMember(user = user, challenge = it, isCreator = false) }
+        val tester2 =
+            challenge?.let { ChallengeMember(user = user, challenge = it, isCreator = false) }
 
         val challengeMember = tester2?.let { challengeMemberRepository.save(it) }
         val userId = challengeMember?.user?.id
@@ -105,7 +106,7 @@ class ChallengeMemberRepositoryTest(
 
     private fun createAndSaveChallenge(): Challenge {
         val dto = getCreateChallengeDto()
-        val challenge = dto.toEntity( "https://url.kr/5MhHhD")
+        val challenge = dto.toEntity("https://url.kr/5MhHhD", "ABC12")
         return challengeRepository.save(challenge)
     }
 

--- a/src/test/kotlin/com/alloon/alloonserver/domain/challenge/ChallengeMemberTest.kt
+++ b/src/test/kotlin/com/alloon/alloonserver/domain/challenge/ChallengeMemberTest.kt
@@ -21,7 +21,7 @@ class ChallengeMemberTest {
             Contact(email = "tester@photi.com", verificationCode = "000000", verifyYn = true)
         val user =
             User(contact = contact, username = "tester", password = "password1!", imageUrl = "")
-        val challenge = getCreateChallengeDto().toEntity("https://url.kr/5MhHhD")
+        val challenge = getCreateChallengeDto().toEntity("https://url.kr/5MhHhD", "ABC12")
         val challengeMember = ChallengeMember(user = user, challenge = challenge)
 
         val goal = "개인목표"

--- a/src/test/kotlin/com/alloon/alloonserver/domain/challenge/ChallengeRepositoryTest.kt
+++ b/src/test/kotlin/com/alloon/alloonserver/domain/challenge/ChallengeRepositoryTest.kt
@@ -79,7 +79,7 @@ class ChallengeRepositoryTest(
 
     private fun createAndSaveChallenge(): Challenge {
         val dto = getCreateChallengeDto()
-        val challenge = dto.toEntity("https://url.kr/5MhHhD")
+        val challenge = dto.toEntity("https://url.kr/5MhHhD", "ABC12")
         return challengeRepository.save(challenge)
     }
 

--- a/src/test/kotlin/com/alloon/alloonserver/domain/challenge/ChallengeTest.kt
+++ b/src/test/kotlin/com/alloon/alloonserver/domain/challenge/ChallengeTest.kt
@@ -15,7 +15,7 @@ class ChallengeTest {
     @Test
     fun givenValid_whenUpdateVisitCnt_thenReturn() {
         // given
-        val challenge = getCreateChallengeDto().toEntity("https://url.kr/5MhHhD")
+        val challenge = getCreateChallengeDto().toEntity("https://url.kr/5MhHhD", "ABC12")
 
         // when
         challenge.updateVisitCnt()

--- a/src/test/kotlin/com/alloon/alloonserver/domain/feed/FeedRepositoryTest.kt
+++ b/src/test/kotlin/com/alloon/alloonserver/domain/feed/FeedRepositoryTest.kt
@@ -73,7 +73,7 @@ class FeedRepositoryTest(
 
     private fun createAndSaveChallenge(): Challenge {
         val dto = getCreateChallengeDto()
-        val challenge = dto.toEntity("https://url.kr/5MhHhD")
+        val challenge = dto.toEntity("https://url.kr/5MhHhD", "ABC12")
         return challengeRepository.save(challenge)
     }
 

--- a/src/test/kotlin/com/alloon/alloonserver/domain/feed/FeedTest.kt
+++ b/src/test/kotlin/com/alloon/alloonserver/domain/feed/FeedTest.kt
@@ -19,7 +19,7 @@ class FeedTest {
     fun givenValid_whenUpdateCommentCnt_thenReturn() {
         // given
         val imageUrl = "https://url.kr/5MhHhD"
-        val challenge = getCreateChallengeDto().toEntity(imageUrl)
+        val challenge = getCreateChallengeDto().toEntity(imageUrl, "ABC12")
         val challengeMember = ChallengeMember(1L, getUser(getContact()), challenge)
         val feed = Feed(1L, challengeMember, challenge, imageUrl, 10, 5)
 
@@ -35,7 +35,7 @@ class FeedTest {
     fun givenCommentCntGreaterThanZero_whenDecreaseCommentCnt_thenReturn() {
         // given
         val imageUrl = "https://url.kr/5MhHhD"
-        val challenge = getCreateChallengeDto().toEntity(imageUrl)
+        val challenge = getCreateChallengeDto().toEntity(imageUrl, "ABC12")
         val challengeMember = ChallengeMember(1L, getUser(getContact()), challenge)
         val feed = Feed(1L, challengeMember, challenge, imageUrl, 10, 5)
 
@@ -51,7 +51,7 @@ class FeedTest {
     fun givenCommentCntZero_whenDecreaseCommentCnt_thenReturn() {
         // given
         val imageUrl = "https://url.kr/5MhHhD"
-        val challenge = getCreateChallengeDto().toEntity(imageUrl)
+        val challenge = getCreateChallengeDto().toEntity(imageUrl, "ABC12")
         val challengeMember = ChallengeMember(1L, getUser(getContact()), challenge)
         val feed = Feed(1L, challengeMember, challenge, imageUrl, 10, 0)
 

--- a/src/test/kotlin/com/alloon/alloonserver/domain/report/ReportRepositoryTest.kt
+++ b/src/test/kotlin/com/alloon/alloonserver/domain/report/ReportRepositoryTest.kt
@@ -77,7 +77,7 @@ class ReportRepositoryTest(
 
     private fun createAndSaveChallenge(): Challenge {
         val dto = getCreateChallengeDto()
-        val challenge = dto.toEntity("https://url.kr/5MhHhD")
+        val challenge = dto.toEntity("https://url.kr/5MhHhD", "ABC12")
         return challengeRepository.save(challenge)
     }
 

--- a/src/test/kotlin/com/alloon/alloonserver/service/challenge/ChallengeServiceTest.kt
+++ b/src/test/kotlin/com/alloon/alloonserver/service/challenge/ChallengeServiceTest.kt
@@ -899,6 +899,67 @@ class ChallengeServiceTest : AbstractMailProperties {
         assertThat(result.content.size).isEqualTo(3)
     }
 
+    @DisplayName("챌린지 초대코드를 조회하면 일치하는 초대코드를 반환한다.")
+    @Test
+    fun givenValid_whenFindChallengeInvitationCode_thenReturn() {
+        // given
+        val userId = 1L
+        val challengeId = 1L
+        val user = getUser()
+        val challenge = getCreateChallengeDto().toEntity("https://url.kr/5MhHhD", "ABC12")
+        val challengeMember = ChallengeMember(user = user, challenge = challenge)
+        val dto = FindChallengeInvitationCodeDto("챌린지 이름", "ABC12")
+
+        every {
+            challengeMemberRepository.findByUserIdAndChallengeId(userId, challengeId)
+        } returns challengeMember
+        every { challengeRepository.findInvitationCodeById(any()) } returns dto
+
+        // when
+        val result = challengeService.findChallengeInvitationCode(userId, challengeId)
+
+        // then
+        assertThat(result).isEqualTo(dto)
+    }
+
+    @DisplayName("등록되지 않은 챌린지 파티원이 챌린지 초대코드를 조회하면 예외가 발생한다.")
+    @Test
+    fun givenNotFoundChallengeMember_whenFindChallengeInvitationCode_thenThrow() {
+        // given
+        val userId = 1L
+        val challengeId = 1L
+
+        every { challengeMemberRepository.findByUserIdAndChallengeId(any(), any()) } returns null
+
+        // when & then
+        assertThatThrownBy { challengeService.findChallengeInvitationCode(userId, challengeId) }
+            .isInstanceOf(CustomException::class.java)
+            .extracting("exceptionCode")
+            .isEqualTo(CHALLENGE_MEMBER_NOT_FOUND)
+    }
+
+    @DisplayName("등록되지 않은 챌린지 초대코드를 조회하면 예외가 발생한다.")
+    @Test
+    fun givenNotFoundChallenge_whenFindChallengeInvitationCode_thenThrow() {
+        // given
+        val userId = 1L
+        val challengeId = 1L
+        val user = getUser()
+        val challenge = getCreateChallengeDto().toEntity("https://url.kr/5MhHhD", "ABC12")
+        val challengeMember = ChallengeMember(user = user, challenge = challenge)
+
+        every {
+            challengeMemberRepository.findByUserIdAndChallengeId(any(), any())
+        } returns challengeMember
+        every { challengeRepository.findInvitationCodeById(any()) } returns null
+
+        // when & then
+        assertThatThrownBy { challengeService.findChallengeInvitationCode(userId, challengeId) }
+            .isInstanceOf(CustomException::class.java)
+            .extracting("exceptionCode")
+            .isEqualTo(CHALLENGE_NOT_FOUND)
+    }
+
     private fun getUser(): User {
         val contact = Contact(1L, "tester@photi.com", "000000", true)
         return User(1L, contact, "tester", "password1!", "")

--- a/src/test/kotlin/com/alloon/alloonserver/service/challenge/ChallengeServiceTest.kt
+++ b/src/test/kotlin/com/alloon/alloonserver/service/challenge/ChallengeServiceTest.kt
@@ -62,7 +62,7 @@ class ChallengeServiceTest : AbstractMailProperties {
         val dto = getCreateChallengeDto()
         val user = getUser()
         val imageUrl = "https://url.kr/5MhHhD"
-        val challenge = dto.toEntity(imageUrl)
+        val challenge = dto.toEntity(imageUrl, "ABC12")
         val challengeMember = ChallengeMember(user = user, challenge = challenge)
         val multipartFile = MockMultipartFile("file", "file.png", "image/png", ByteArray(1))
 
@@ -129,7 +129,7 @@ class ChallengeServiceTest : AbstractMailProperties {
     fun givenValid_whenFindChallengeInfo_thenReturn() {
         // given
         val challengeId = 1L
-        val challenge = getCreateChallengeDto().toEntity("https://url.kr/5MhHhD")
+        val challenge = getCreateChallengeDto().toEntity("https://url.kr/5MhHhD", "ABC12")
         val dto = getFindChallengeInfoDto()
 
         every { challengeRepository.findInfoById(any()) } returns challenge
@@ -164,7 +164,7 @@ class ChallengeServiceTest : AbstractMailProperties {
         val challengeId = 1L
         val dto = UpdateChallengeMemberGoalDto("개인목표")
 
-        val challenge = getCreateChallengeDto().toEntity("https://url.kr/5MhHhD")
+        val challenge = getCreateChallengeDto().toEntity("https://url.kr/5MhHhD", "ABC12")
         val challengeMember = ChallengeMember(user = getUser(), challenge = challenge)
 
         every {
@@ -240,7 +240,7 @@ class ChallengeServiceTest : AbstractMailProperties {
     fun givenValid_whenFindAllChallenge_thenReturn() {
         // given
         val challengeId = 1L
-        val challenge = getCreateChallengeDto().toEntity("https://url.kr/5MhHhD")
+        val challenge = getCreateChallengeDto().toEntity("https://url.kr/5MhHhD", "ABC12")
         val dto = getFindChallengeDto()
 
         every { challengeRepository.findInfoById(any()) } returns challenge
@@ -266,7 +266,7 @@ class ChallengeServiceTest : AbstractMailProperties {
         val dto = getUpdateChallengeDto()
         val multipartFile = MockMultipartFile("file", "file.png", "image/png", ByteArray(1))
         val imageUrl = "https://url.kr/5MhHhD2345"
-        val challenge = getCreateChallengeDto().toEntity("https://url.kr/5MhHhD")
+        val challenge = getCreateChallengeDto().toEntity("https://url.kr/5MhHhD", "ABC12")
         val challengeMember = ChallengeMember(user = getUser(), challenge = challenge)
 
         every { challengeRepository.findInfoById(any()) } returns challenge
@@ -296,7 +296,7 @@ class ChallengeServiceTest : AbstractMailProperties {
         val userId = 1L
         val challengeId = 1L
         val challenge = getCreateChallengeDto()
-            .toEntity("https://url.kr/5MhHhD")
+            .toEntity("https://url.kr/5MhHhD", "ABC12")
             .apply { currentMemberCnt = 3 }
         val challengeMember = ChallengeMember(user = getUser(), challenge = challenge)
 
@@ -323,7 +323,7 @@ class ChallengeServiceTest : AbstractMailProperties {
         val userId = 1L
         val challengeId = 1L
         val challenge = getCreateChallengeDto()
-            .toEntity("https://url.kr/5MhHhD")
+            .toEntity("https://url.kr/5MhHhD", "ABC12")
             .apply { currentMemberCnt = 1 }
         val challengeMember = ChallengeMember(user = getUser(), challenge = challenge)
 
@@ -350,7 +350,7 @@ class ChallengeServiceTest : AbstractMailProperties {
         // given
         val user = getUser()
         val imageUrl = "https://url.kr/5MhHhD"
-        val challenge = getCreateChallengeDto().toEntity(imageUrl)
+        val challenge = getCreateChallengeDto().toEntity(imageUrl, "ABC12")
         val challengeMember = ChallengeMember(user = user, challenge = challenge)
         val multipartFile = MockMultipartFile("file", "file.png", "image/png", ByteArray(1))
         val feed =
@@ -381,7 +381,7 @@ class ChallengeServiceTest : AbstractMailProperties {
         // given
         val user = getUser()
         val imageUrl = "https://url.kr/5MhHhD"
-        val challenge = getCreateChallengeDto().toEntity(imageUrl)
+        val challenge = getCreateChallengeDto().toEntity(imageUrl, "ABC12")
         val challengeMember = ChallengeMember(user = user, challenge = challenge)
         val multipartFile = MockMultipartFile("file", "file.png", "image/png", ByteArray(1))
 
@@ -410,7 +410,7 @@ class ChallengeServiceTest : AbstractMailProperties {
         val feedId = 1L
         val imageUrl = "https://url.kr/5MhHhD"
         val user = getUser()
-        val challenge = getCreateChallengeDto().toEntity(imageUrl)
+        val challenge = getCreateChallengeDto().toEntity(imageUrl, "ABC12")
         val challengeMember = ChallengeMember(user = user, challenge = challenge)
         val feed = Feed(1L, challengeMember, challenge, imageUrl, 1)
         val feedComments = listOf(
@@ -481,7 +481,7 @@ class ChallengeServiceTest : AbstractMailProperties {
         // given
         val user = getUser()
         val imageUrl = "https://url.kr/5MhHhD"
-        val challenge = getCreateChallengeDto().toEntity(imageUrl)
+        val challenge = getCreateChallengeDto().toEntity(imageUrl, "ABC12")
         val userId = 1L
         val challengeId = 1L
         val feedId = 1L
@@ -503,7 +503,7 @@ class ChallengeServiceTest : AbstractMailProperties {
         // given
         val user = getUser()
         val imageUrl = "https://url.kr/5MhHhD"
-        val challenge = getCreateChallengeDto().toEntity(imageUrl)
+        val challenge = getCreateChallengeDto().toEntity(imageUrl, "ABC12")
         val challengeMember = ChallengeMember(user = user, challenge = challenge)
         val userId = 1L
         val challengeId = 1L
@@ -553,7 +553,7 @@ class ChallengeServiceTest : AbstractMailProperties {
         // given
         val user = getUser()
         val imageUrl = "https://url.kr/5MhHhD"
-        val challenge = getCreateChallengeDto().toEntity(imageUrl)
+        val challenge = getCreateChallengeDto().toEntity(imageUrl, "ABC12")
         val challengeMember = ChallengeMember(user = user, challenge = challenge)
         val userId = 1L
         val challengeId = 1L
@@ -604,7 +604,7 @@ class ChallengeServiceTest : AbstractMailProperties {
     fun givenNotFoundChallengeMember_whenCreateChallengeFeedComment_thenThrow() {
         // given
         val imageUrl = "https://url.kr/5MhHhD"
-        val challenge = getCreateChallengeDto().toEntity(imageUrl)
+        val challenge = getCreateChallengeDto().toEntity(imageUrl, "ABC12")
         val userId = 1L
         val challengeId = 1L
         val feedId = 1L
@@ -631,7 +631,7 @@ class ChallengeServiceTest : AbstractMailProperties {
         // given
         val user = getUser()
         val imageUrl = "https://url.kr/5MhHhD"
-        val challenge = getCreateChallengeDto().toEntity(imageUrl)
+        val challenge = getCreateChallengeDto().toEntity(imageUrl, "ABC12")
         val challengeMember = ChallengeMember(user = user, challenge = challenge)
         val userId = 1L
         val challengeId = 1L
@@ -660,7 +660,7 @@ class ChallengeServiceTest : AbstractMailProperties {
         // given
         val user = getUser()
         val imageUrl = "https://url.kr/5MhHhD"
-        val challenge = getCreateChallengeDto().toEntity(imageUrl)
+        val challenge = getCreateChallengeDto().toEntity(imageUrl, "ABC12")
         val challengeMember = ChallengeMember(user = user, challenge = challenge)
         val feed =
             Feed(challengeMember = challengeMember, challenge = challenge, imageUrl = imageUrl)
@@ -710,7 +710,7 @@ class ChallengeServiceTest : AbstractMailProperties {
     fun givenNotFoundFeed_whenDeleteChallengeFeedComment_thenThrow() {
         // given
         val imageUrl = "https://url.kr/5MhHhD"
-        val challenge = getCreateChallengeDto().toEntity(imageUrl)
+        val challenge = getCreateChallengeDto().toEntity(imageUrl, "ABC12")
         val userId = 1L
         val challengeId = 1L
         val feedId = 1L
@@ -734,7 +734,7 @@ class ChallengeServiceTest : AbstractMailProperties {
         // given
         val user = getUser()
         val imageUrl = "https://url.kr/5MhHhD"
-        val challenge = getCreateChallengeDto().toEntity(imageUrl)
+        val challenge = getCreateChallengeDto().toEntity(imageUrl, "ABC12")
         val challengeMember = ChallengeMember(user = user, challenge = challenge)
         val feed =
             Feed(challengeMember = challengeMember, challenge = challenge, imageUrl = imageUrl)
@@ -764,7 +764,7 @@ class ChallengeServiceTest : AbstractMailProperties {
         // given
         val user = getUser()
         val imageUrl = "https://url.kr/5MhHhD"
-        val challenge = getCreateChallengeDto().toEntity(imageUrl)
+        val challenge = getCreateChallengeDto().toEntity(imageUrl, "ABC12")
         val challengeMember = ChallengeMember(user = user, challenge = challenge)
         val feed =
             Feed(challengeMember = challengeMember, challenge = challenge, imageUrl = imageUrl)
@@ -797,7 +797,7 @@ class ChallengeServiceTest : AbstractMailProperties {
         val challengeId = 1L
         val feedId = 1L
         val user = getUser()
-        val challenge = getCreateChallengeDto().toEntity("https://url.kr/5MhHhD")
+        val challenge = getCreateChallengeDto().toEntity("https://url.kr/5MhHhD", "ABC12")
         val challengeMember = ChallengeMember(user = user, challenge = challenge)
         val dto = getFindChallengeFeedDto()
 
@@ -838,7 +838,7 @@ class ChallengeServiceTest : AbstractMailProperties {
         val userId = 1L
         val challengeId = 1L
         val feedId = 1L
-        val challenge = getCreateChallengeDto().toEntity("https://url.kr/5MhHhD")
+        val challenge = getCreateChallengeDto().toEntity("https://url.kr/5MhHhD", "ABC12")
 
         every { challengeRepository.findInfoById(any()) } returns challenge
         every {
@@ -860,7 +860,7 @@ class ChallengeServiceTest : AbstractMailProperties {
         val challengeId = 1L
         val feedId = 1L
         val user = getUser()
-        val challenge = getCreateChallengeDto().toEntity("https://url.kr/5MhHhD")
+        val challenge = getCreateChallengeDto().toEntity("https://url.kr/5MhHhD", "ABC12")
         val challengeMember = ChallengeMember(user = user, challenge = challenge)
 
         every { challengeRepository.findInfoById(any()) } returns challenge

--- a/src/test/kotlin/com/alloon/alloonserver/service/report/ReportServiceTest.kt
+++ b/src/test/kotlin/com/alloon/alloonserver/service/report/ReportServiceTest.kt
@@ -211,7 +211,7 @@ class ReportServiceTest(
 
     private fun createAndSaveChallenge(): Challenge {
         val dto = getCreateChallengeDto()
-        val challenge = dto.toEntity("https://url.kr/5MhHhD")
+        val challenge = dto.toEntity("https://url.kr/5MhHhD","ABC12")
         return challengeRepository.save(challenge)
     }
 

--- a/src/test/resources/init.sql
+++ b/src/test/resources/init.sql
@@ -59,7 +59,7 @@ CREATE TABLE challenge
     start_date                  DATE                      NOT NULL,
     current_member_cnt          INT                       NOT NULL,
     visit_cnt                   INT                       NOT NULL,
-    is_recruit                  BOOLEAN                   NOT NULL,
+    invitation_code             VARCHAR(5)                NOT NULL,
     create_date_time            TIMESTAMP(6)              NOT NULL,
     update_date_time            TIMESTAMP(6)              NOT NULL,
     service_status              VARCHAR(10)               NOT NULL,


### PR DESCRIPTION
## 📋 이슈 번호
- close #157 
  </br>

## 🛠 구현 사항
- 챌린지 생성시 초대코드 랜덤 5글자(숫자, 영어 대문자) 저장
- challenge 엔티티 변경으로 인한 schema 수정
- 챌린지 이름, 초대코드 조회
  </br>

## 📚 기타
- 
  </br>