### PR TITLE
[feat] 종료된 챌린지 조회 API

### DIFF
--- a/src/main/kotlin/com/alloon/alloonserver/api/controller/user/UserController.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/api/controller/user/UserController.kt
@@ -134,4 +134,25 @@ class UserController(
 
         return ResponseEntity.ok(response)
     }
+
+    @GetMapping("/ended-challenges")
+    @Operation(
+        summary = "사용자 종료된 챌린지 조회",
+        security = [SecurityRequirement(name = ACCESS_TOKEN_KEY)],
+        description = "챌린지 종료 날짜 최신순으로 정렬되어 조회됩니다. 챌린지 파티원 이미지는 최근 가입순으로 최대 3개 조회됩니다."
+    )
+    @ApiResponse(responseCode = "200")
+    @ApiErrorResponses([TOKEN_UNAUTHENTICATED, TOKEN_UNAUTHORIZED])
+    fun findUserEndedChallenges(
+        principal: Principal,
+        @Parameter(description = "페이지 시작 번호") @RequestParam(defaultValue = "0") page: Int,
+        @Parameter(description = "한 페이지당 content 최대 갯수") @RequestParam(defaultValue = "10") size: Int,
+    ): ResponseEntity<SliceResponse<FindUserEndedChallengesResponse>> {
+        val pageable = PageRequest.of(page, size)
+        val userFeeds =
+            userService.findUserEndedChallenges(UserUtility.getUserId(principal), pageable)
+        val response = SliceResponse.of(userFeeds)
+
+        return ResponseEntity.ok(response)
+    }
 }

--- a/src/main/kotlin/com/alloon/alloonserver/api/controller/user/response/FindUserEndedChallengesResponse.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/api/controller/user/response/FindUserEndedChallengesResponse.kt
@@ -1,0 +1,53 @@
+package com.alloon.alloonserver.api.controller.user.response
+
+import com.alloon.alloonserver.api.controller.challenge.response.ChallengeMemberImageResponse
+import com.alloon.alloonserver.service.user.dto.FindUserEndedChallengesDto
+import com.fasterxml.jackson.annotation.JsonFormat
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDate
+
+@Schema(description = "사용자 종료된 챌린지 조회 응답 객체")
+data class FindUserEndedChallengesResponse(
+
+    @Schema(description = "챌린지 id", example = "1")
+    val id: Long,
+
+    @Schema(description = "챌린지 이름", example = "신나게 하는 러닝 챌린지")
+    val name: String,
+
+    @Schema(description = "챌린지 대표 이미지", example = "https://url.kr/5MhHhD")
+    val imageUrl: String,
+
+    @field:JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+    @Schema(description = "챌린지 종료 날짜", example = "2024-12-01")
+    val endDate: LocalDate,
+
+    @Schema(description = "챌린지 파티원 수", example = "5")
+    val currentMemberCnt: Int,
+
+    @Schema(
+        description = "챌린지 파티원 이미지 리스트", example = """
+        [
+            {"memberImage": "https://url.kr/5MhHhD"},
+            {"memberImage": "https://url.kr/5MhHhD"},
+            {"memberImage": "https://url.kr/5MhHhD"}
+        ]
+    """
+    )
+    val memberImages: List<ChallengeMemberImageResponse>,
+) {
+
+    companion object {
+
+        fun of(challenge: FindUserEndedChallengesDto): FindUserEndedChallengesResponse {
+            return FindUserEndedChallengesResponse(
+                challenge.id,
+                challenge.name,
+                challenge.imageUrl,
+                challenge.endDate,
+                challenge.currentMemberCnt,
+                challenge.memberImages.map { ChallengeMemberImageResponse(it.imageUrl) }
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/alloon/alloonserver/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/config/SecurityConfig.kt
@@ -41,6 +41,7 @@ class SecurityConfig(
                     "/api/users/challenges",
                     "/api/users/feeds-by-date",
                     "/api/users/feed-history",
+                    "/api/users/ended-challenges",
                     "/api/challenges/{challengeId}/info",
                     "/api/challenges/{challengeId}/invitation-code",
                     "/api/challenges/{challengeId}/challenge-members/goal",

--- a/src/main/kotlin/com/alloon/alloonserver/domain/user/custom/UserCustomRepository.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/domain/user/custom/UserCustomRepository.kt
@@ -23,4 +23,6 @@ interface UserCustomRepository {
     fun findFeedsByDate(userId: Long, date: LocalDate): List<FindUserFeedsByDateDto>
 
     fun findFeedHistoryById(userId: Long, pageable: Pageable): Slice<FindUserFeedHistoryDto>
+
+    fun findEndedChallengesById(userId: Long, pageable: Pageable): Slice<FindUserEndedChallengesDto>
 }

--- a/src/main/kotlin/com/alloon/alloonserver/domain/user/custom/UserCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/domain/user/custom/UserCustomRepositoryImpl.kt
@@ -6,6 +6,7 @@ import com.alloon.alloonserver.domain.feed.QFeed.feed
 import com.alloon.alloonserver.domain.user.QContact.contact
 import com.alloon.alloonserver.domain.user.QUser.user
 import com.alloon.alloonserver.domain.user.User
+import com.alloon.alloonserver.service.challenge.dto.QUserImageDto
 import com.alloon.alloonserver.service.user.dto.*
 import com.querydsl.core.types.dsl.BooleanExpression
 import com.querydsl.core.types.dsl.Expressions
@@ -156,6 +157,58 @@ class UserCustomRepositoryImpl(
             .offset(pageable.offset)
             .limit(pageSize + 1L)
             .fetch()
+
+        val hasNext = if (content.size > pageSize) {
+            content.removeAt(pageSize)
+            true
+        } else {
+            false
+        }
+
+        return SliceImpl(content, pageable, hasNext)
+    }
+
+    override fun findEndedChallengesById(
+        userId: Long,
+        pageable: Pageable
+    ): Slice<FindUserEndedChallengesDto> {
+        val pageSize = pageable.pageSize
+        val content = queryFactory
+            .select(
+                QFindUserEndedChallengesDto(
+                    challengeMember.challenge.id,
+                    challengeMember.challenge.name,
+                    challengeMember.challenge.imageUrl,
+                    challengeMember.challenge.endDate,
+                    challengeMember.challenge.currentMemberCnt,
+                    Expressions.constant(emptyList())
+                )
+            )
+            .from(challengeMember)
+            .join(challengeMember.user)
+            .join(challengeMember.challenge)
+            .where(
+                challengeMember.user.id.eq(userId),
+                challengeMember.challenge.serviceStatus.eq(END)
+            )
+            .orderBy(challengeMember.challenge.endDate.desc())
+            .offset(pageable.offset)
+            .limit(pageSize + 1L)
+            .fetch()
+
+        val challengeIds = content.map { it.id }
+        val memberImages = queryFactory
+            .select(QUserImageDto(challengeMember.challenge.id, challengeMember.user.imageUrl))
+            .from(challengeMember)
+            .where(challengeMember.challenge.id.`in`(challengeIds))
+            .orderBy(challengeMember.createDateTime.desc())
+            .limit(3)
+            .fetch()
+            .groupBy { it.challengeId }
+
+        content.forEach {
+            it.memberImages = memberImages[it.id] ?: emptyList()
+        }
 
         val hasNext = if (content.size > pageSize) {
             content.removeAt(pageSize)

--- a/src/main/kotlin/com/alloon/alloonserver/service/challenge/dto/UserImageDto.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/service/challenge/dto/UserImageDto.kt
@@ -1,0 +1,8 @@
+package com.alloon.alloonserver.service.challenge.dto
+
+import com.querydsl.core.annotations.QueryProjection
+
+data class UserImageDto @QueryProjection constructor(
+    val challengeId: Long,
+    val imageUrl: String,
+)

--- a/src/main/kotlin/com/alloon/alloonserver/service/user/UserService.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/service/user/UserService.kt
@@ -1,5 +1,6 @@
 package com.alloon.alloonserver.service.user
 
+import com.alloon.alloonserver.api.controller.user.response.FindUserEndedChallengesResponse
 import com.alloon.alloonserver.api.controller.user.response.FindUserFeedHistoryResponse
 import com.alloon.alloonserver.common.constant.ExceptionCode.USER_NOT_FOUND
 import com.alloon.alloonserver.common.response.CustomException
@@ -64,6 +65,14 @@ class UserService(
     fun findUserFeedHistory(userId: Long, pageable: Pageable): Slice<FindUserFeedHistoryResponse> {
         return userRepository.findFeedHistoryById(userId, pageable)
             .map { FindUserFeedHistoryResponse.of(it) }
+    }
+
+    fun findUserEndedChallenges(
+        userId: Long,
+        pageable: Pageable
+    ): Slice<FindUserEndedChallengesResponse> {
+        return userRepository.findEndedChallengesById(userId, pageable)
+            .map { FindUserEndedChallengesResponse.of(it) }
     }
 
     private fun deleteOriginalImage(imageUrl: String) {

--- a/src/main/kotlin/com/alloon/alloonserver/service/user/dto/FindUserEndedChallengesDto.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/service/user/dto/FindUserEndedChallengesDto.kt
@@ -1,0 +1,14 @@
+package com.alloon.alloonserver.service.user.dto
+
+import com.alloon.alloonserver.service.challenge.dto.UserImageDto
+import com.querydsl.core.annotations.QueryProjection
+import java.time.LocalDate
+
+data class FindUserEndedChallengesDto @QueryProjection constructor(
+    val id: Long,
+    val name: String,
+    val imageUrl: String,
+    val endDate: LocalDate,
+    val currentMemberCnt: Int,
+    var memberImages: List<UserImageDto>,
+)

--- a/src/test/kotlin/com/alloon/alloonserver/api/controller/user/UserControllerTest.kt
+++ b/src/test/kotlin/com/alloon/alloonserver/api/controller/user/UserControllerTest.kt
@@ -1,8 +1,9 @@
 package com.alloon.alloonserver.api.controller.user
 
 import com.alloon.alloonserver.api.controller.RestDocsSupport
-import com.alloon.alloonserver.api.controller.challenge.response.FindChallengesResponse
+import com.alloon.alloonserver.api.controller.user.response.FindUserEndedChallengesResponse
 import com.alloon.alloonserver.api.controller.user.response.FindUserFeedHistoryResponse
+import com.alloon.alloonserver.service.challenge.dto.UserImageDto
 import com.alloon.alloonserver.service.user.UserService
 import com.alloon.alloonserver.service.user.dto.*
 import io.mockk.every
@@ -17,6 +18,7 @@ import org.springframework.mock.web.MockMultipartFile
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
 
@@ -172,6 +174,32 @@ class UserControllerTest : RestDocsSupport() {
         resultActions.andExpect(status().isOk)
     }
 
+    @DisplayName("사용자 종료된 챌린지 조회를 성공하면 200을 반환한다.")
+    @Test
+    fun givenValid_whenFindUserEndedChallenges_thenReturn200() {
+        // given
+        val dto = getFindUserEndedChallengesDto()
+        val content = listOf(FindUserEndedChallengesResponse.of(dto))
+        val pageable = PageRequest.of(0, 10)
+        val hasNext = true
+
+        every { userService.findUserEndedChallenges(any(), any()) } returns SliceImpl(
+            content,
+            pageable,
+            hasNext
+        )
+
+        // when
+        val resultActions = mockMvc.perform(
+            get("/api/users/ended-challenges")
+                .header(AUTHORIZATION, "Bearer access-token")
+                .principal(mockPrincipal)
+        )
+
+        // then
+        resultActions.andExpect(status().isOk)
+    }
+
     private fun getUserInfoDto(): UserInfoDto {
         return UserInfoDto("https://url.kr/5MhHhD", "tester", "tester@photi.com")
     }
@@ -186,6 +214,21 @@ class UserControllerTest : RestDocsSupport() {
             "https://url.kr/5MhHhD",
             "챌린지 이름",
             LocalTime.of(13, 0)
+        )
+    }
+
+    private fun getFindUserEndedChallengesDto(): FindUserEndedChallengesDto {
+        return FindUserEndedChallengesDto(
+            1L,
+            "챌린지 이름",
+            "https://url.kr/5MhHhD",
+            LocalDate.of(2024, 12, 1),
+            3,
+            listOf(
+                UserImageDto(1L, "https://url.kr/5MhHhD"),
+                UserImageDto(1L, "https://url.kr/5MhHhE"),
+                UserImageDto(1L, "https://url.kr/5MhHhF")
+            )
         )
     }
 }

--- a/src/test/kotlin/com/alloon/alloonserver/service/user/UserServiceTest.kt
+++ b/src/test/kotlin/com/alloon/alloonserver/service/user/UserServiceTest.kt
@@ -6,6 +6,7 @@ import com.alloon.alloonserver.domain.user.Contact
 import com.alloon.alloonserver.domain.user.User
 import com.alloon.alloonserver.domain.user.UserRepository
 import com.alloon.alloonserver.framework.TestContainerInitializer
+import com.alloon.alloonserver.service.challenge.dto.UserImageDto
 import com.alloon.alloonserver.service.s3.S3Service
 import com.alloon.alloonserver.service.user.dto.*
 import io.mockk.Runs
@@ -240,6 +241,29 @@ class UserServiceTest {
         assertThat(result.content.size).isEqualTo(3)
     }
 
+    @DisplayName("사용자 종료된 챌린지 조회를 하면 페이징 객체를 반환한다.")
+    @Test
+    fun givenValid_whenFindUserEndedChallenges_thenReturn() {
+        // given
+        val userId = 1L
+        val dto = getFindUserEndedChallengesDto()
+        val content = listOf(dto, dto, dto)
+        val pageable = PageRequest.of(0, 10)
+        val hasNext = true
+
+        every { userRepository.findEndedChallengesById(any(), any()) } returns SliceImpl(
+            content,
+            pageable,
+            hasNext
+        )
+
+        // when
+        val result = userService.findUserEndedChallenges(userId, pageable)
+
+        // then
+        assertThat(result.content.size).isEqualTo(3)
+    }
+
     private fun getUser(): User {
         val contact = Contact(1L, "tester@photi.com", "000000", true)
         return User(1L, contact, "tester", "password1!", "")
@@ -263,6 +287,21 @@ class UserServiceTest {
             "https://url.kr/5MhHhD",
             "챌린지 이름",
             LocalTime.of(13, 0)
+        )
+    }
+
+    private fun getFindUserEndedChallengesDto(): FindUserEndedChallengesDto {
+        return FindUserEndedChallengesDto(
+            1L,
+            "챌린지 이름",
+            "https://url.kr/5MhHhD",
+            LocalDate.of(2024, 12, 1),
+            3,
+            listOf(
+                UserImageDto(1L, "https://url.kr/5MhHhD"),
+                UserImageDto(1L, "https://url.kr/5MhHhE"),
+                UserImageDto(1L, "https://url.kr/5MhHhF")
+            )
         )
     }
 }


### PR DESCRIPTION
## 📋 이슈 번호
- close #152 
  </br>

## 🛠 구현 사항
- 챌린지 이미지, 챌린지 이름, 챌린지 종료 날짜, 챌린지 id, 챌린지 파티원 수, 챌린지 파티원 이미지 리스트 조회
- 페이징 처리
- 챌린지 종료 날짜 최신순으로 정렬
- 챌린지 파티원 이미지 리스트의 경우, 챌린지 id가 먼저 조회되어야 불러올 수 있기 때문에
  1) 먼저 챌린지 이미지, 챌린지 이름, 챌린지 종료 날짜, 챌린지 id, 챌린지 파티원 수 조회
  2) 챌린지 파티원 이미지 리스트는 emptyList로 초기화
  3) 챌린지 파티원의 챌린지 id가 조회된 챌린지 id 리스트에 포함되는지 확인
  4) 챌린지 파티원 이미지 리스트 조회후 groupBy로 챌린지 id를 key, 이미지 dto를 value로 갖는 Map 생성
  5) emptyList였던 챌린지 파티원 이미지 리스트에 Map의 value값 대입
  </br>

## 📚 기타
- 
  </br>