### PR TITLE
[feat] 내 챌린지 조회 API

### DIFF
--- a/src/main/kotlin/com/alloon/alloonserver/api/controller/user/UserController.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/api/controller/user/UserController.kt
@@ -155,4 +155,25 @@ class UserController(
 
         return ResponseEntity.ok(response)
     }
+
+    @GetMapping("/my-challenges")
+    @Operation(
+        summary = "사용자 참여 중인 챌린지 조회",
+        security = [SecurityRequirement(name = ACCESS_TOKEN_KEY)],
+        description = "챌린지 인증시간이 빠른 순(ex. 4시 -> 18시 -> 20시)으로 정렬되어 조회됩니다."
+    )
+    @ApiResponse(responseCode = "200")
+    @ApiErrorResponses([TOKEN_UNAUTHENTICATED, TOKEN_UNAUTHORIZED])
+    fun findUserChallenges(
+        principal: Principal,
+        @Parameter(description = "페이지 시작 번호") @RequestParam(defaultValue = "0") page: Int,
+        @Parameter(description = "한 페이지당 content 최대 갯수") @RequestParam(defaultValue = "10") size: Int,
+    ): ResponseEntity<SliceResponse<FindUserChallengesResponse>> {
+        val pageable = PageRequest.of(page, size)
+        val userChallenges =
+            userService.findUserChallenges(UserUtility.getUserId(principal), pageable)
+        val response = SliceResponse.of(userChallenges)
+
+        return ResponseEntity.ok(response)
+    }
 }

--- a/src/main/kotlin/com/alloon/alloonserver/api/controller/user/response/FindUserChallengesResponse.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/api/controller/user/response/FindUserChallengesResponse.kt
@@ -1,0 +1,58 @@
+package com.alloon.alloonserver.api.controller.user.response
+
+import com.alloon.alloonserver.api.controller.challenge.response.ChallengeHashtagResponse
+import com.alloon.alloonserver.service.user.dto.FindUserChallengesDto
+import com.fasterxml.jackson.annotation.JsonFormat
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDate
+import java.time.LocalTime
+
+@Schema(description = "사용자 참여 중인 챌린지 조회 응답 객체")
+data class FindUserChallengesResponse(
+
+    @Schema(description = "챌린지 id", example = "1")
+    val id: Long,
+
+    @Schema(description = "챌린지 이름", example = "신나게 하는 러닝 챌린지")
+    val name: String,
+
+    @Schema(description = "챌린지 대표 이미지", example = "https://url.kr/5MhHhD")
+    val challengeImageUrl: String,
+
+    @Schema(description = "챌린지 인증 시간", example = "13:00")
+    @field:JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "kk:mm")
+    val proveTime: LocalTime,
+
+    @field:JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+    @Schema(description = "챌린지 종료 날짜", example = "2024-12-01")
+    val endDate: LocalDate,
+
+    @Schema(
+        description = "챌린지 해시태그 리스트", example = """
+        [
+            {"hashtag": "러닝"},
+            {"hashtag": "건강"}
+        ]
+    """
+    )
+    val hashtags: List<ChallengeHashtagResponse>,
+
+    @Schema(description = "피드 이미지", example = "https://url.kr/5MhHhD")
+    val feedImageUrl: String,
+) {
+
+    companion object {
+
+        fun of(challenge: FindUserChallengesDto): FindUserChallengesResponse {
+            return FindUserChallengesResponse(
+                challenge.id,
+                challenge.name,
+                challenge.challengeImageUrl,
+                challenge.proveTime,
+                challenge.endDate,
+                challenge.hashtags.map { ChallengeHashtagResponse(it) },
+                challenge.feedImageUrl,
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/alloon/alloonserver/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/config/SecurityConfig.kt
@@ -42,6 +42,7 @@ class SecurityConfig(
                     "/api/users/feeds-by-date",
                     "/api/users/feed-history",
                     "/api/users/ended-challenges",
+                    "/api/users/my-challenges",
                     "/api/challenges/{challengeId}/info",
                     "/api/challenges/{challengeId}/invitation-code",
                     "/api/challenges/{challengeId}/challenge-members/goal",

--- a/src/main/kotlin/com/alloon/alloonserver/domain/user/custom/UserCustomRepository.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/domain/user/custom/UserCustomRepository.kt
@@ -25,4 +25,6 @@ interface UserCustomRepository {
     fun findFeedHistoryById(userId: Long, pageable: Pageable): Slice<FindUserFeedHistoryDto>
 
     fun findEndedChallengesById(userId: Long, pageable: Pageable): Slice<FindUserEndedChallengesDto>
+
+    fun findUserChallengesById(userId: Long, pageable: Pageable): Slice<FindUserChallengesDto>
 }

--- a/src/main/kotlin/com/alloon/alloonserver/domain/user/custom/UserCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/domain/user/custom/UserCustomRepositoryImpl.kt
@@ -220,6 +220,55 @@ class UserCustomRepositoryImpl(
         return SliceImpl(content, pageable, hasNext)
     }
 
+    override fun findUserChallengesById(
+        userId: Long,
+        pageable: Pageable
+    ): Slice<FindUserChallengesDto> {
+        val pageSize = pageable.pageSize
+        val content = queryFactory
+            .select(
+                QFindUserChallengesDto(
+                    challengeMember.challenge.id,
+                    challengeMember.challenge.name,
+                    challengeMember.challenge.imageUrl,
+                    challengeMember.challenge.proveTime,
+                    challengeMember.challenge.endDate,
+                    challengeMember.challenge.hashtags,
+                    Expressions.constant(""),
+                )
+            )
+            .from(challengeMember)
+            .join(challengeMember.challenge)
+            .join(challengeMember.user)
+            .where(challengeMember.user.id.eq(userId))
+            .orderBy(challengeMember.challenge.proveTime.asc())
+            .offset(pageable.offset)
+            .limit(pageSize + 1L)
+            .fetch()
+
+        val challengeIds = content.map { it.id }
+        val feedImageUrls = queryFactory
+            .select(QUserImageDto(feed.challenge.id, feed.imageUrl))
+            .from(feed)
+            .join(feed.challengeMember)
+            .where(feed.challengeMember.user.id.eq(userId), feed.challenge.id.`in`(challengeIds))
+            .fetch()
+            .groupBy { it.challengeId }
+
+        content.forEach {
+            it.feedImageUrl = feedImageUrls[it.id]?.first()?.imageUrl ?: ""
+        }
+
+        val hasNext = if (content.size > pageSize) {
+            content.removeAt(pageSize)
+            true
+        } else {
+            false
+        }
+
+        return SliceImpl(content, pageable, hasNext)
+    }
+
     private fun eqUserId(userId: Long?): BooleanExpression? = userId?.let { user.id.eq(it) }
 
     private fun eqEmail(email: String?): BooleanExpression? = email?.let { contact.email.eq(it) }

--- a/src/main/kotlin/com/alloon/alloonserver/service/user/UserService.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/service/user/UserService.kt
@@ -1,5 +1,6 @@
 package com.alloon.alloonserver.service.user
 
+import com.alloon.alloonserver.api.controller.user.response.FindUserChallengesResponse
 import com.alloon.alloonserver.api.controller.user.response.FindUserEndedChallengesResponse
 import com.alloon.alloonserver.api.controller.user.response.FindUserFeedHistoryResponse
 import com.alloon.alloonserver.common.constant.ExceptionCode.USER_NOT_FOUND
@@ -73,6 +74,11 @@ class UserService(
     ): Slice<FindUserEndedChallengesResponse> {
         return userRepository.findEndedChallengesById(userId, pageable)
             .map { FindUserEndedChallengesResponse.of(it) }
+    }
+
+    fun findUserChallenges(userId: Long, pageable: Pageable): Slice<FindUserChallengesResponse> {
+        return userRepository.findUserChallengesById(userId, pageable)
+            .map { FindUserChallengesResponse.of(it) }
     }
 
     private fun deleteOriginalImage(imageUrl: String) {

--- a/src/main/kotlin/com/alloon/alloonserver/service/user/dto/FindUserChallengesDto.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/service/user/dto/FindUserChallengesDto.kt
@@ -1,0 +1,15 @@
+package com.alloon.alloonserver.service.user.dto
+
+import com.querydsl.core.annotations.QueryProjection
+import java.time.LocalDate
+import java.time.LocalTime
+
+data class FindUserChallengesDto @QueryProjection constructor(
+    val id: Long,
+    val name: String,
+    val challengeImageUrl: String,
+    val proveTime: LocalTime,
+    val endDate: LocalDate,
+    val hashtags: List<String>,
+    var feedImageUrl: String,
+)

--- a/src/test/kotlin/com/alloon/alloonserver/api/controller/user/UserControllerTest.kt
+++ b/src/test/kotlin/com/alloon/alloonserver/api/controller/user/UserControllerTest.kt
@@ -1,6 +1,7 @@
 package com.alloon.alloonserver.api.controller.user
 
 import com.alloon.alloonserver.api.controller.RestDocsSupport
+import com.alloon.alloonserver.api.controller.user.response.FindUserChallengesResponse
 import com.alloon.alloonserver.api.controller.user.response.FindUserEndedChallengesResponse
 import com.alloon.alloonserver.api.controller.user.response.FindUserFeedHistoryResponse
 import com.alloon.alloonserver.service.challenge.dto.UserImageDto
@@ -200,6 +201,32 @@ class UserControllerTest : RestDocsSupport() {
         resultActions.andExpect(status().isOk)
     }
 
+    @DisplayName("사용자 참여 중인 챌린지 조회를 성공하면 200을 반환한다.")
+    @Test
+    fun givenValid_whenFindUserChallenges_thenReturn200() {
+        // given
+        val dto = getFindUserChallengesDto()
+        val content = listOf(FindUserChallengesResponse.of(dto))
+        val pageable = PageRequest.of(0, 10)
+        val hasNext = true
+
+        every { userService.findUserChallenges(any(), any()) } returns SliceImpl(
+            content,
+            pageable,
+            hasNext
+        )
+
+        // when
+        val resultActions = mockMvc.perform(
+            get("/api/users/my-challenges")
+                .header(AUTHORIZATION, "Bearer access-token")
+                .principal(mockPrincipal)
+        )
+
+        // then
+        resultActions.andExpect(status().isOk)
+    }
+
     private fun getUserInfoDto(): UserInfoDto {
         return UserInfoDto("https://url.kr/5MhHhD", "tester", "tester@photi.com")
     }
@@ -229,6 +256,18 @@ class UserControllerTest : RestDocsSupport() {
                 UserImageDto(1L, "https://url.kr/5MhHhE"),
                 UserImageDto(1L, "https://url.kr/5MhHhF")
             )
+        )
+    }
+
+    private fun getFindUserChallengesDto(): FindUserChallengesDto {
+        return FindUserChallengesDto(
+            1L,
+            "챌린지 이름",
+            "https://url.kr/5MhHhD",
+            LocalTime.of(13, 0),
+            LocalDate.of(2024, 12, 1),
+            listOf("러닝", "건강"),
+            "https://url.kr/5MhHhD",
         )
     }
 }

--- a/src/test/kotlin/com/alloon/alloonserver/service/user/UserServiceTest.kt
+++ b/src/test/kotlin/com/alloon/alloonserver/service/user/UserServiceTest.kt
@@ -264,6 +264,29 @@ class UserServiceTest {
         assertThat(result.content.size).isEqualTo(3)
     }
 
+    @DisplayName("사용자 참여 중인 챌린지 조회를 하면 페이징 객체를 반환한다.")
+    @Test
+    fun givenValid_whenFindUserChallenges_thenReturn() {
+        // given
+        val userId = 1L
+        val dto = getFindUserChallengesDto()
+        val content = listOf(dto, dto, dto)
+        val pageable = PageRequest.of(0, 10)
+        val hasNext = true
+
+        every { userRepository.findUserChallengesById(any(), any()) } returns SliceImpl(
+            content,
+            pageable,
+            hasNext
+        )
+
+        // when
+        val result = userService.findUserChallenges(userId, pageable)
+
+        // then
+        assertThat(result.content.size).isEqualTo(3)
+    }
+
     private fun getUser(): User {
         val contact = Contact(1L, "tester@photi.com", "000000", true)
         return User(1L, contact, "tester", "password1!", "")
@@ -302,6 +325,18 @@ class UserServiceTest {
                 UserImageDto(1L, "https://url.kr/5MhHhE"),
                 UserImageDto(1L, "https://url.kr/5MhHhF")
             )
+        )
+    }
+
+    private fun getFindUserChallengesDto(): FindUserChallengesDto {
+        return FindUserChallengesDto(
+            1L,
+            "챌린지 이름",
+            "https://url.kr/5MhHhD",
+            LocalTime.of(13, 0),
+            LocalDate.of(2024, 12, 1),
+            listOf("러닝", "건강"),
+            "https://url.kr/5MhHhD",
         )
     }
 }


### PR DESCRIPTION
## 📋 이슈 번호
- close #164 
  </br>

## 🛠 구현 사항
- 챌린지 이름, 이미지, 종료 날짜, 인증 시간, 해시태그 리스트, 인증 사진
- 인증시간이 빠른 순으로 (ex. 4시 -> 18시 -> 20시) 정렬
- 페이징 처리
  </br>

## 📚 기타
- 
  </br>