### PR TITLE
[feat] 해시태그 리스트 조회 API

### DIFF
--- a/src/main/kotlin/com/alloon/alloonserver/api/controller/challenge/ChallengeController.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/api/controller/challenge/ChallengeController.kt
@@ -334,4 +334,14 @@ class ChallengeController(
 
         return ResponseEntity.ok(response)
     }
+
+    @GetMapping("/hashtags")
+    @Operation(summary = "해시태그 리스트 조회", description = "챌린지에 가장 많이 사용된 순으로 정렬되어 최대 10개 조회됩니다.")
+    @ApiResponse(responseCode = "200")
+    fun findPopularChallengeHashtags(): ResponseEntity<List<FindPopularChallengeHashtagsResponse>> {
+        val hashtags = challengeService.findPopularChallengeHashtags()
+        val response = FindPopularChallengeHashtagsResponse.of(hashtags)
+
+        return ResponseEntity.ok(response)
+    }
 }

--- a/src/main/kotlin/com/alloon/alloonserver/api/controller/challenge/response/FindPopularChallengeHashtagsResponse.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/api/controller/challenge/response/FindPopularChallengeHashtagsResponse.kt
@@ -1,0 +1,16 @@
+package com.alloon.alloonserver.api.controller.challenge.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "해시태그 리스트 조회 응답 객체")
+data class FindPopularChallengeHashtagsResponse(
+    val hashtag: String,
+) {
+
+    companion object {
+
+        fun of(hashtags: Set<String>): List<FindPopularChallengeHashtagsResponse> {
+            return hashtags.map { FindPopularChallengeHashtagsResponse(it) }
+        }
+    }
+}

--- a/src/main/kotlin/com/alloon/alloonserver/api/controller/challenge/response/FindPopularChallengeHashtagsResponse.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/api/controller/challenge/response/FindPopularChallengeHashtagsResponse.kt
@@ -4,6 +4,8 @@ import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(description = "해시태그 리스트 조회 응답 객체")
 data class FindPopularChallengeHashtagsResponse(
+
+    @Schema(description = "챌린지 해시태그", example = "러닝")
     val hashtag: String,
 ) {
 

--- a/src/main/kotlin/com/alloon/alloonserver/common/exception/CustomAsyncUncaughtExceptionHandler.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/common/exception/CustomAsyncUncaughtExceptionHandler.kt
@@ -1,0 +1,17 @@
+package com.alloon.alloonserver.common.exception
+
+import org.slf4j.LoggerFactory
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler
+import java.lang.reflect.Method
+
+class CustomAsyncUncaughtExceptionHandler : AsyncUncaughtExceptionHandler {
+
+    private val logger = LoggerFactory.getLogger(CustomAsyncUncaughtExceptionHandler::class.java)
+
+    override fun handleUncaughtException(ex: Throwable, method: Method, vararg params: Any?) {
+        logger.error("Exception occurred in async method: ${method.name}", ex.message)
+        if (params.isNotEmpty()) {
+            logger.error("Method parameters: ${params.joinToString()}")
+        }
+    }
+}

--- a/src/main/kotlin/com/alloon/alloonserver/config/AsyncConfig.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/config/AsyncConfig.kt
@@ -1,17 +1,28 @@
 package com.alloon.alloonserver.config
 
+import com.alloon.alloonserver.common.exception.CustomAsyncUncaughtExceptionHandler
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler
 import org.springframework.context.annotation.Configuration
 import org.springframework.scheduling.annotation.AsyncConfigurer
 import org.springframework.scheduling.annotation.EnableAsync
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
 import java.util.concurrent.Executor
-import java.util.concurrent.LinkedBlockingQueue
-import java.util.concurrent.ThreadPoolExecutor
-import java.util.concurrent.TimeUnit
 
 @EnableAsync
 @Configuration
 class AsyncConfig : AsyncConfigurer {
 
-    override fun getAsyncExecutor(): Executor =
-        ThreadPoolExecutor(10, 30, 30, TimeUnit.SECONDS, LinkedBlockingQueue())
+    override fun getAsyncExecutor(): Executor? {
+        return ThreadPoolTaskExecutor().apply {
+            corePoolSize = 3
+            maxPoolSize = 10
+            queueCapacity = 500
+            setThreadNamePrefix("Executor-")
+            initialize()
+        }
+    }
+
+    override fun getAsyncUncaughtExceptionHandler(): AsyncUncaughtExceptionHandler {
+        return CustomAsyncUncaughtExceptionHandler()
+    }
 }

--- a/src/main/kotlin/com/alloon/alloonserver/service/challenge/ChallengeService.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/service/challenge/ChallengeService.kt
@@ -35,6 +35,7 @@ class ChallengeService(
     private val feedRepository: FeedRepository,
     private val feedCommentRepository: FeedCommentRepository,
     private val s3Service: S3Service,
+    private val hashtagService: HashtagService,
 ) {
 
     @Transactional
@@ -53,6 +54,7 @@ class ChallengeService(
 
         challengeRepository.save(challenge)
         challengeMemberRepository.save(challengeMember)
+        hashtagService.addHashtags(challenge.hashtags)
 
         return CreateChallengeDto.of(challenge)
     }
@@ -113,6 +115,7 @@ class ChallengeService(
         s3Service.deleteImage(challenge.imageUrl, CHALLENGES)
         val fileName = s3Service.uploadImage(imageFile, CHALLENGES)
         val imageUrl = s3Service.getImageUrl(fileName)
+        hashtagService.updateHashtags(challenge.hashtags)
 
         dto.updateChallenge(challenge, imageUrl)
     }
@@ -130,6 +133,8 @@ class ChallengeService(
         } else {
             challenge.decreaseCurrentMemberCnt()
         }
+
+        hashtagService.deleteHashtags(challenge.hashtags)
     }
 
     @Transactional
@@ -224,6 +229,10 @@ class ChallengeService(
         validateChallengeMember(userId, challengeId)
         return challengeRepository.findInvitationCodeById(challengeId)
             ?: throw CustomException(CHALLENGE_NOT_FOUND)
+    }
+
+    fun findPopularChallengeHashtags(): Set<String> {
+        return hashtagService.findPopularChallengeHashtags()
     }
 
     private fun validateUser(userId: Long): User {

--- a/src/main/kotlin/com/alloon/alloonserver/service/challenge/HashtagService.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/service/challenge/HashtagService.kt
@@ -1,0 +1,48 @@
+package com.alloon.alloonserver.service.challenge
+
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.scheduling.annotation.Async
+import org.springframework.stereotype.Service
+
+@Service
+class HashtagService(private val redisTemplate: RedisTemplate<String, String>) {
+
+    @Async
+    fun addHashtags(hashtags: List<String>) {
+        hashtags.forEach { hashtag ->
+            redisTemplate.opsForZSet().incrementScore(POPULAR_HASHTAGS_KEY, hashtag, 1.0)
+        }
+    }
+
+    @Async
+    fun updateHashtags(hashtags: List<String>) {
+        hashtags.forEach { hashtag ->
+            val score = redisTemplate.opsForZSet().score(POPULAR_HASHTAGS_KEY, hashtag)
+            if (score == null) {
+                redisTemplate.opsForZSet().incrementScore(POPULAR_HASHTAGS_KEY, hashtag, 1.0)
+            }
+        }
+    }
+
+    @Async
+    fun deleteHashtags(hashtags: List<String>) {
+        hashtags.forEach { hashtag ->
+            val score = redisTemplate.opsForZSet().score(POPULAR_HASHTAGS_KEY, hashtag)
+            if (score != null) {
+                redisTemplate.opsForZSet().incrementScore(POPULAR_HASHTAGS_KEY, hashtag, -1.0)
+                if (score <= 0) {
+                    redisTemplate.opsForZSet().remove(POPULAR_HASHTAGS_KEY, hashtag)
+                }
+            }
+        }
+    }
+
+    fun findPopularChallengeHashtags(): Set<String> {
+        return redisTemplate.opsForZSet()
+            .reverseRange(POPULAR_HASHTAGS_KEY, 0, 9) ?: emptySet()
+    }
+
+    companion object {
+        const val POPULAR_HASHTAGS_KEY = "popular:hashtags"
+    }
+}

--- a/src/test/kotlin/com/alloon/alloonserver/service/challenge/ChallengeServiceTest.kt
+++ b/src/test/kotlin/com/alloon/alloonserver/service/challenge/ChallengeServiceTest.kt
@@ -45,6 +45,7 @@ class ChallengeServiceTest : AbstractMailProperties {
     private val feedRepository = mockk<FeedRepository>()
     private val feedCommentRepository = mockk<FeedCommentRepository>()
     private val s3Service = mockk<S3Service>()
+    private val hashtagService = mockk<HashtagService>()
 
     private val challengeService = ChallengeService(
         challengeRepository,
@@ -52,7 +53,8 @@ class ChallengeServiceTest : AbstractMailProperties {
         userRepository,
         feedRepository,
         feedCommentRepository,
-        s3Service
+        s3Service,
+        hashtagService,
     )
 
     @DisplayName("챌린지 생성을 하면 정상 작동한다")
@@ -71,6 +73,7 @@ class ChallengeServiceTest : AbstractMailProperties {
         every { s3Service.getImageUrl(any()) } returns imageUrl
         every { challengeRepository.save(any()) } returns challenge
         every { challengeMemberRepository.save(any()) } returns challengeMember
+        every { hashtagService.addHashtags(any()) } just Runs
 
         // when
         val result = challengeService.createChallenge(1L, dto, multipartFile)
@@ -276,6 +279,7 @@ class ChallengeServiceTest : AbstractMailProperties {
         every { s3Service.deleteImage(any(), any()) } just Runs
         every { s3Service.uploadImage(any(), any()) } returns ""
         every { s3Service.getImageUrl(any()) } returns imageUrl
+        every { hashtagService.updateHashtags(any()) } just Runs
 
         // when
         challengeService.updateChallenge(userId, challengeId, dto, multipartFile)
@@ -305,6 +309,7 @@ class ChallengeServiceTest : AbstractMailProperties {
             challengeMemberRepository.findByUserIdAndChallengeId(any(), any())
         } returns challengeMember
         every { challengeMemberRepository.delete(any()) } just Runs
+        every { hashtagService.deleteHashtags(any()) } just Runs
 
         // when
         challengeService.deleteChallenge(userId, challengeId)
@@ -334,6 +339,7 @@ class ChallengeServiceTest : AbstractMailProperties {
         every { challengeMemberRepository.delete(any()) } just Runs
         every { challengeRepository.deleteById(any()) } just Runs
         every { s3Service.deleteImage(any(), any()) } just Runs
+        every { hashtagService.deleteHashtags(any()) } just Runs
 
         // when
         challengeService.deleteChallenge(userId, challengeId)


### PR DESCRIPTION
## 📋 이슈 번호
- close #158 
  </br>

## 🛠 구현 사항
- 챌린지 중에서 가장 많이 사용된 해시태그 최대 10개 조회
- 레디스 SortedSet 사용
  </br>

## 📚 기타
- 데이터 정합성 유지를 위해 레디스와 DB 동기화 필요
- 주기적으로 저장(스프링 배치)
  </br>