### PR TITLE
[feat] 챌린지 이름 검색 API

### DIFF
--- a/src/main/kotlin/com/alloon/alloonserver/api/controller/challenge/ChallengeController.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/api/controller/challenge/ChallengeController.kt
@@ -367,7 +367,7 @@ class ChallengeController(
     @GetMapping("/search/name")
     @Operation(
         summary = "챌린지 이름 검색",
-        description = "[1순위 - 검색어와 완전히 일치하는 이름 / 2순위 - 검색어가 포함된 이름 / 3순위 - 최신순]으로 현재 진행 중인 챌린지만 조회됩니다."
+        description = "[1순위 - 검색어와 완전히 일치하는 이름 / 2순위 - 검색어가 포함된 이름 / 3순위 - 종료 날짜 최신순]으로 현재 진행 중인 챌린지만 조회됩니다."
     )
     @ApiResponse(responseCode = "200")
     fun searchChallengeByName(

--- a/src/main/kotlin/com/alloon/alloonserver/api/controller/challenge/ChallengeController.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/api/controller/challenge/ChallengeController.kt
@@ -363,4 +363,22 @@ class ChallengeController(
 
         return ResponseEntity.ok(response)
     }
+
+    @GetMapping("/search/name")
+    @Operation(
+        summary = "챌린지 이름 검색",
+        description = "[1순위 - 검색어와 완전히 일치하는 이름 / 2순위 - 검색어가 포함된 이름 / 3순위 - 최신순]으로 현재 진행 중인 챌린지만 조회됩니다."
+    )
+    @ApiResponse(responseCode = "200")
+    fun searchChallengeByName(
+        @Parameter(description = "챌린지 이름", example = "러닝 챌린지") @RequestParam challengeName: String,
+        @Parameter(description = "페이지 시작 번호") @RequestParam(defaultValue = "0") page: Int,
+        @Parameter(description = "한 페이지당 content 최대 갯수") @RequestParam(defaultValue = "10") size: Int,
+    ): ResponseEntity<SliceResponse<SearchChallengeByNameResponse>> {
+        val pageable = PageRequest.of(page, size)
+        val challenges = challengeService.searchChallengeByName(challengeName, pageable)
+        val response = SliceResponse.of(challenges)
+
+        return ResponseEntity.ok(response)
+    }
 }

--- a/src/main/kotlin/com/alloon/alloonserver/api/controller/challenge/response/SearchChallengeByNameResponse.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/api/controller/challenge/response/SearchChallengeByNameResponse.kt
@@ -1,0 +1,55 @@
+package com.alloon.alloonserver.api.controller.challenge.response
+
+import com.alloon.alloonserver.service.challenge.dto.SearchChallengeByNameDto
+import com.fasterxml.jackson.annotation.JsonFormat
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDate
+
+data class SearchChallengeByNameResponse(
+
+    @Schema(description = "챌린지 id", example = "1")
+    val id: Long,
+
+    @Schema(description = "챌린지 이름", example = "신나게 하는 러닝 챌린지")
+    val name: String,
+
+    @Schema(description = "챌린지 대표 이미지", example = "https://url.kr/5MhHhD")
+    val imageUrl: String,
+
+    @Schema(description = "챌린지 파티원 수", example = "5")
+    val currentMemberCnt: Int,
+
+    @field:JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+    @Schema(description = "챌린지 종료 날짜", example = "2024-12-01")
+    val endDate: LocalDate,
+
+    @Schema(
+        description = "챌린지 파티원 이미지 리스트", example = """
+        [
+            {"memberImage": "https://url.kr/5MhHhD"},
+            {"memberImage": "https://url.kr/5MhHhD"},
+            {"memberImage": "https://url.kr/5MhHhD"}
+        ]
+    """
+    )
+    val memberImages: List<ChallengeMemberImageResponse>,
+) {
+
+    companion object {
+
+        fun of(challenge: SearchChallengeByNameDto): SearchChallengeByNameResponse {
+            return SearchChallengeByNameResponse(
+                challenge.id,
+                challenge.name,
+                challenge.imageUrl,
+                challenge.currentMemberCnt,
+                challenge.endDate,
+                challenge.memberImages.map { ChallengeMemberImageResponse(it) },
+            )
+        }
+
+        fun of(challenges: List<SearchChallengeByNameDto>): List<SearchChallengeByNameResponse> {
+            return challenges.map { of(it) }
+        }
+    }
+}

--- a/src/main/kotlin/com/alloon/alloonserver/domain/challenge/custom/ChallengeCustomRepository.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/domain/challenge/custom/ChallengeCustomRepository.kt
@@ -4,6 +4,7 @@ import com.alloon.alloonserver.domain.challenge.Challenge
 import com.alloon.alloonserver.service.challenge.dto.FindChallengeInvitationCodeDto
 import com.alloon.alloonserver.service.challenge.dto.FindChallengesDto
 import com.alloon.alloonserver.service.challenge.dto.FindPopularChallengesDto
+import com.alloon.alloonserver.service.challenge.dto.SearchChallengeByNameDto
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Slice
 
@@ -24,4 +25,6 @@ interface ChallengeCustomRepository {
         popularHashtags: List<String>? = null,
         pageable: Pageable,
     ): Slice<FindChallengesDto>
+
+    fun searchByName(name: String, pageable: Pageable): Slice<SearchChallengeByNameDto>
 }

--- a/src/main/kotlin/com/alloon/alloonserver/domain/challenge/custom/ChallengeCustomRepository.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/domain/challenge/custom/ChallengeCustomRepository.kt
@@ -16,7 +16,7 @@ interface ChallengeCustomRepository {
 
     fun findInfoById(id: Long): Challenge?
 
-    fun findAllOrderByStartDate(pageable: Pageable): Slice<FindChallengesDto>
+    fun findAllOrderByEndDate(pageable: Pageable): Slice<FindChallengesDto>
 
     fun findInvitationCodeById(id: Long): FindChallengeInvitationCodeDto?
 

--- a/src/main/kotlin/com/alloon/alloonserver/domain/challenge/custom/ChallengeCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/domain/challenge/custom/ChallengeCustomRepositoryImpl.kt
@@ -84,7 +84,7 @@ class ChallengeCustomRepositoryImpl(
             .fetchFirst()
     }
 
-    override fun findAllOrderByStartDate(pageable: Pageable): Slice<FindChallengesDto> {
+    override fun findAllOrderByEndDate(pageable: Pageable): Slice<FindChallengesDto> {
         val pageSize = pageable.pageSize
         val content = queryFactory
             .select(
@@ -98,7 +98,7 @@ class ChallengeCustomRepositoryImpl(
             )
             .from(challenge)
             .where(eqServiceStatus(ACTIVE))
-            .orderBy(challenge.startDate.desc())
+            .orderBy(challenge.endDate.desc())
             .offset(pageable.offset)
             .limit(pageSize + 1L)
             .fetch()
@@ -224,7 +224,7 @@ class ChallengeCustomRepositoryImpl(
                     "case when {0} = {1} then 1 when {0} like {2} then 2 else 3 end",
                     challenge.name, name, "%$name%",
                 ).asc(),
-                challenge.createDateTime.desc(),
+                challenge.endDate.desc(),
             )
             .fetch()
 

--- a/src/main/kotlin/com/alloon/alloonserver/domain/challenge/custom/ChallengeCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/domain/challenge/custom/ChallengeCustomRepositoryImpl.kt
@@ -203,6 +203,51 @@ class ChallengeCustomRepositoryImpl(
         return SliceImpl(content, pageable, hasNext)
     }
 
+    override fun searchByName(name: String, pageable: Pageable): Slice<SearchChallengeByNameDto> {
+        val pageSize = pageable.pageSize
+        val content = queryFactory
+            .select(
+                QSearchChallengeByNameDto(
+                    challenge.id,
+                    challenge.name,
+                    challenge.imageUrl,
+                    challenge.currentMemberCnt,
+                    challenge.endDate,
+                    Expressions.constant(emptyList()),
+                )
+            )
+            .from(challenge)
+            .where(eqServiceStatus(ACTIVE), challenge.name.containsIgnoreCase(name))
+            .orderBy(
+                Expressions.numberTemplate(
+                    Int::class.java,
+                    "case when {0} = {1} then 1 when {0} like {2} then 2 else 3 end",
+                    challenge.name, name, "%$name%",
+                ).asc(),
+                challenge.createDateTime.desc(),
+            )
+            .fetch()
+
+        content.forEach {
+            it.memberImages = queryFactory
+                .select(challengeMember.user.imageUrl)
+                .from(challengeMember)
+                .where(challengeMember.challenge.id.eq(it.id))
+                .orderBy(challengeMember.createDateTime.desc())
+                .limit(3)
+                .fetch()
+        }
+
+        val hasNext = if (content.size > pageSize) {
+            content.removeAt(pageSize)
+            true
+        } else {
+            false
+        }
+
+        return SliceImpl(content, pageable, hasNext)
+    }
+
     private fun eqServiceStatus(serviceStatus: ServiceStatus?): BooleanExpression? =
         serviceStatus?.let { challenge.serviceStatus.eq(serviceStatus) }
 }

--- a/src/main/kotlin/com/alloon/alloonserver/service/challenge/ChallengeService.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/service/challenge/ChallengeService.kt
@@ -89,7 +89,7 @@ class ChallengeService(
     }
 
     fun findAllChallenges(pageable: Pageable): Slice<FindChallengesResponse> {
-        return challengeRepository.findAllOrderByStartDate(pageable)
+        return challengeRepository.findAllOrderByEndDate(pageable)
             .map { FindChallengesResponse.of(it) }
     }
 

--- a/src/main/kotlin/com/alloon/alloonserver/service/challenge/ChallengeService.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/service/challenge/ChallengeService.kt
@@ -3,6 +3,7 @@ package com.alloon.alloonserver.service.challenge
 import com.alloon.alloonserver.api.controller.challenge.response.FindChallengeFeedCommentsResponse
 import com.alloon.alloonserver.api.controller.challenge.response.FindChallengeFeedsByDateResponse
 import com.alloon.alloonserver.api.controller.challenge.response.FindChallengesResponse
+import com.alloon.alloonserver.api.controller.challenge.response.SearchChallengeByNameResponse
 import com.alloon.alloonserver.common.constant.ExceptionCode.*
 import com.alloon.alloonserver.common.constant.SortTypeConstants
 import com.alloon.alloonserver.common.response.CustomException
@@ -249,6 +250,14 @@ class ChallengeService(
             challengeRepository.findAllByHashtag(hashtag = hashtag, pageable = pageable)
                 .map { FindChallengesResponse.of(it) }
         }
+    }
+
+    fun searchChallengeByName(
+        challengeName: String,
+        pageable: Pageable
+    ): Slice<SearchChallengeByNameResponse> {
+        return challengeRepository.searchByName(challengeName, pageable)
+            .map { SearchChallengeByNameResponse.of(it) }
     }
 
     private fun validateUser(userId: Long): User {

--- a/src/main/kotlin/com/alloon/alloonserver/service/challenge/dto/SearchChallengeByNameDto.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/service/challenge/dto/SearchChallengeByNameDto.kt
@@ -1,0 +1,13 @@
+package com.alloon.alloonserver.service.challenge.dto
+
+import com.querydsl.core.annotations.QueryProjection
+import java.time.LocalDate
+
+data class SearchChallengeByNameDto @QueryProjection constructor(
+    val id: Long,
+    val name: String,
+    val imageUrl: String,
+    val currentMemberCnt: Int,
+    val endDate: LocalDate,
+    var memberImages: List<String>,
+)

--- a/src/test/kotlin/com/alloon/alloonserver/service/challenge/ChallengeServiceTest.kt
+++ b/src/test/kotlin/com/alloon/alloonserver/service/challenge/ChallengeServiceTest.kt
@@ -225,7 +225,7 @@ class ChallengeServiceTest : AbstractMailProperties {
         val pageable = PageRequest.of(0, 10)
         val hasNext = true
 
-        every { challengeRepository.findAllOrderByStartDate(any()) } returns SliceImpl(
+        every { challengeRepository.findAllOrderByEndDate(any()) } returns SliceImpl(
             content,
             pageable,
             hasNext


### PR DESCRIPTION
## 📋 이슈 번호
- close #160 
  </br>

## 🛠 구현 사항
- 1순위 - 검색어와 완전히 일치하는 이름
- 2순위 - 검색어가 포함된 이름
- 3순위 - 최신순으로
- 현재 진행 중인 챌린지만 조회
- 챌린지 이름, 이미지, 종료 날짜, 파티원 수, 파티원 이미지 리스트 조회
- 페이징 처리
  </br>

## 📚 기타
- 
  </br>