### PR TITLE
[feat] 챌린지 해시태그 검색 API

### DIFF
--- a/src/main/kotlin/com/alloon/alloonserver/api/controller/challenge/ChallengeController.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/api/controller/challenge/ChallengeController.kt
@@ -381,4 +381,22 @@ class ChallengeController(
 
         return ResponseEntity.ok(response)
     }
+
+    @GetMapping("/search/hashtag")
+    @Operation(
+        summary = "챌린지 해시태그 검색",
+        description = "[1순위 - 검색어와 완전히 일치하는 해시태그 / 2순위 - 검색어가 포함된 해시태그 / 3순위 - 종료 날짜 최신순]으로 현재 진행 중인 챌린지만 조회됩니다."
+    )
+    @ApiResponse(responseCode = "200")
+    fun searchChallengeByHashtag(
+        @Parameter(description = "챌린지 해시태그", example = "러닝") @RequestParam hashtag: String,
+        @Parameter(description = "페이지 시작 번호") @RequestParam(defaultValue = "0") page: Int,
+        @Parameter(description = "한 페이지당 content 최대 갯수") @RequestParam(defaultValue = "10") size: Int,
+    ): ResponseEntity<SliceResponse<SearchChallengeByHashtagResponse>> {
+        val pageable = PageRequest.of(page, size)
+        val challenges = challengeService.searchChallengeByHashtag(hashtag, pageable)
+        val response = SliceResponse.of(challenges)
+
+        return ResponseEntity.ok(response)
+    }
 }

--- a/src/main/kotlin/com/alloon/alloonserver/api/controller/challenge/response/SearchChallengeByHashtagResponse.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/api/controller/challenge/response/SearchChallengeByHashtagResponse.kt
@@ -1,0 +1,66 @@
+package com.alloon.alloonserver.api.controller.challenge.response
+
+import com.alloon.alloonserver.service.challenge.dto.SearchChallengeByHashtagDto
+import com.fasterxml.jackson.annotation.JsonFormat
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDate
+
+data class SearchChallengeByHashtagResponse(
+
+    @Schema(description = "챌린지 id", example = "1")
+    val id: Long,
+
+    @Schema(description = "챌린지 이름", example = "신나게 하는 러닝 챌린지")
+    val name: String,
+
+    @Schema(description = "챌린지 대표 이미지", example = "https://url.kr/5MhHhD")
+    val imageUrl: String,
+
+    @Schema(description = "챌린지 파티원 수", example = "5")
+    val currentMemberCnt: Int,
+
+    @field:JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+    @Schema(description = "챌린지 종료 날짜", example = "2024-12-01")
+    val endDate: LocalDate,
+
+    @Schema(
+        description = "챌린지 해시태그 리스트", example = """
+        [
+            {"hashtag": "러닝"},
+            {"hashtag": "건강"}
+        ]
+    """
+    )
+    val hashtags: List<ChallengeHashtagResponse>,
+
+    @Schema(
+        description = "챌린지 파티원 이미지 리스트", example = """
+        [
+            {"memberImage": "https://url.kr/5MhHhD"},
+            {"memberImage": "https://url.kr/5MhHhD"},
+            {"memberImage": "https://url.kr/5MhHhD"}
+        ]
+    """
+    )
+    val memberImages: List<ChallengeMemberImageResponse>,
+) {
+
+    companion object {
+
+        fun of(challenge: SearchChallengeByHashtagDto): SearchChallengeByHashtagResponse {
+            return SearchChallengeByHashtagResponse(
+                challenge.id,
+                challenge.name,
+                challenge.imageUrl,
+                challenge.currentMemberCnt,
+                challenge.endDate,
+                challenge.hashtags.map { ChallengeHashtagResponse(it.hashtag) },
+                challenge.memberImages.map { ChallengeMemberImageResponse(it) },
+            )
+        }
+
+        fun of(challenges: List<SearchChallengeByHashtagDto>): List<SearchChallengeByHashtagResponse> {
+            return challenges.map { of(it) }
+        }
+    }
+}

--- a/src/main/kotlin/com/alloon/alloonserver/domain/challenge/custom/ChallengeCustomRepository.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/domain/challenge/custom/ChallengeCustomRepository.kt
@@ -1,10 +1,7 @@
 package com.alloon.alloonserver.domain.challenge.custom
 
 import com.alloon.alloonserver.domain.challenge.Challenge
-import com.alloon.alloonserver.service.challenge.dto.FindChallengeInvitationCodeDto
-import com.alloon.alloonserver.service.challenge.dto.FindChallengesDto
-import com.alloon.alloonserver.service.challenge.dto.FindPopularChallengesDto
-import com.alloon.alloonserver.service.challenge.dto.SearchChallengeByNameDto
+import com.alloon.alloonserver.service.challenge.dto.*
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Slice
 
@@ -27,4 +24,6 @@ interface ChallengeCustomRepository {
     ): Slice<FindChallengesDto>
 
     fun searchByName(name: String, pageable: Pageable): Slice<SearchChallengeByNameDto>
+
+    fun searchByHashtag(hashtag: String, pageable: Pageable): Slice<SearchChallengeByHashtagDto>
 }

--- a/src/main/kotlin/com/alloon/alloonserver/domain/challenge/custom/ChallengeCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/domain/challenge/custom/ChallengeCustomRepositoryImpl.kt
@@ -248,6 +248,70 @@ class ChallengeCustomRepositoryImpl(
         return SliceImpl(content, pageable, hasNext)
     }
 
+    override fun searchByHashtag(
+        hashtag: String,
+        pageable: Pageable
+    ): Slice<SearchChallengeByHashtagDto> {
+        val pageSize = pageable.pageSize
+        val content = queryFactory
+            .select(
+                QSearchChallengeByHashtagDto(
+                    challenge.id,
+                    challenge.name,
+                    challenge.imageUrl,
+                    challenge.currentMemberCnt,
+                    challenge.endDate,
+                    Expressions.constant(emptyList()),
+                    Expressions.constant(emptyList()),
+                )
+            )
+            .from(challenge)
+            .join(challenge.hashtags, challengeHashtag)
+            .where(eqServiceStatus(ACTIVE), challengeHashtag.hashtag.containsIgnoreCase(hashtag))
+            .orderBy(
+                Expressions.numberTemplate(
+                    Int::class.java,
+                    "case when {0} = {1} then 1 when {0} like {2} then 2 else 3 end",
+                    challengeHashtag.hashtag, hashtag, "%$hashtag%"
+                ).asc(),
+                challenge.endDate.desc(),
+            )
+            .fetch()
+
+        val challengeIds = content.map { it.id }
+        val hashtags = queryFactory
+            .select(
+                QFindChallengeHashtagDto(
+                    challengeHashtag.challenge.id,
+                    challengeHashtag.hashtag
+                )
+            )
+            .from(challengeHashtag)
+            .where(challengeHashtag.challenge.id.`in`(challengeIds))
+            .fetch()
+            .groupBy { it.challengeId }
+
+        content.forEach {
+            it.hashtags = hashtags[it.id] ?: emptyList()
+            it.memberImages = queryFactory
+                .select(challengeMember.user.imageUrl)
+                .from(challengeMember)
+                .where(challengeMember.challenge.id.eq(it.id))
+                .orderBy(challengeMember.createDateTime.desc())
+                .limit(3)
+                .fetch()
+        }
+
+        val hasNext = if (content.size > pageSize) {
+            content.removeAt(pageSize)
+            true
+        } else {
+            false
+        }
+
+        return SliceImpl(content, pageable, hasNext)
+    }
+
     private fun eqServiceStatus(serviceStatus: ServiceStatus?): BooleanExpression? =
         serviceStatus?.let { challenge.serviceStatus.eq(serviceStatus) }
 }

--- a/src/main/kotlin/com/alloon/alloonserver/service/challenge/ChallengeService.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/service/challenge/ChallengeService.kt
@@ -1,9 +1,6 @@
 package com.alloon.alloonserver.service.challenge
 
-import com.alloon.alloonserver.api.controller.challenge.response.FindChallengeFeedCommentsResponse
-import com.alloon.alloonserver.api.controller.challenge.response.FindChallengeFeedsByDateResponse
-import com.alloon.alloonserver.api.controller.challenge.response.FindChallengesResponse
-import com.alloon.alloonserver.api.controller.challenge.response.SearchChallengeByNameResponse
+import com.alloon.alloonserver.api.controller.challenge.response.*
 import com.alloon.alloonserver.common.constant.ExceptionCode.*
 import com.alloon.alloonserver.common.constant.SortTypeConstants
 import com.alloon.alloonserver.common.response.CustomException
@@ -258,6 +255,14 @@ class ChallengeService(
     ): Slice<SearchChallengeByNameResponse> {
         return challengeRepository.searchByName(challengeName, pageable)
             .map { SearchChallengeByNameResponse.of(it) }
+    }
+
+    fun searchChallengeByHashtag(
+        hashtag: String,
+        pageable: Pageable
+    ): Slice<SearchChallengeByHashtagResponse> {
+        return challengeRepository.searchByHashtag(hashtag, pageable)
+            .map { SearchChallengeByHashtagResponse.of(it) }
     }
 
     private fun validateUser(userId: Long): User {

--- a/src/main/kotlin/com/alloon/alloonserver/service/challenge/dto/SearchChallengeByHashtagDto.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/service/challenge/dto/SearchChallengeByHashtagDto.kt
@@ -1,0 +1,14 @@
+package com.alloon.alloonserver.service.challenge.dto
+
+import com.querydsl.core.annotations.QueryProjection
+import java.time.LocalDate
+
+data class SearchChallengeByHashtagDto @QueryProjection constructor(
+    val id: Long,
+    val name: String,
+    val imageUrl: String,
+    val currentMemberCnt: Int,
+    val endDate: LocalDate,
+    var hashtags: List<FindChallengeHashtagDto>,
+    var memberImages: List<String>,
+)


### PR DESCRIPTION
## 📋 이슈 번호
- close #161 
  </br>

## 🛠 구현 사항
- 1순위 - 검색어와 완전히 일치하는 해시태그
- 2순위 - 검색어가 포함된 해시태그
- 3순위 - 최신순으로
- 현재 진행 중인 챌린지만 조회
- 챌린지 이름, 이미지, 종료 날짜, 파티원 수, 파티원 이미지 리스트, 해시태그 리스트 조회
- 페이징 처리
  </br>

## 📚 기타
- 
  </br>