### PR TITLE
[feat] 공개 챌린지 참여하기 API

### DIFF
--- a/src/main/kotlin/com/alloon/alloonserver/api/controller/challenge/ChallengeController.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/api/controller/challenge/ChallengeController.kt
@@ -399,4 +399,22 @@ class ChallengeController(
 
         return ResponseEntity.ok(response)
     }
+
+    @PostMapping("/{challengeId}/join/public")
+    @Operation(summary = "공개 챌린지 참여하기", security = [SecurityRequirement(name = ACCESS_TOKEN_KEY)])
+    @ApiResponse(responseCode = "200")
+    @ApiErrorResponses([TOKEN_UNAUTHENTICATED, TOKEN_UNAUTHORIZED, USER_NOT_FOUND, CHALLENGE_NOT_FOUND, EXISTING_CHALLENGE_MEMBER])
+    fun joinPublicChallenge(
+        principal: Principal,
+        @PathVariable @Parameter(description = "챌린지 id", example = "1") challengeId: Long,
+        @RequestBody(required = false) @Valid request: JoinPublicChallengeRequest,
+    ): ResponseEntity<StringSuccessResponse> {
+        challengeService.joinPublicChallenge(
+            UserUtility.getUserId(principal),
+            challengeId,
+            request.toServiceDto()
+        )
+
+        return ResponseEntity.ok(StringSuccessResponse("공개 챌린지 참여하기가 완료되었습니다."))
+    }
 }

--- a/src/main/kotlin/com/alloon/alloonserver/api/controller/challenge/ChallengeController.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/api/controller/challenge/ChallengeController.kt
@@ -407,7 +407,7 @@ class ChallengeController(
     fun joinPublicChallenge(
         principal: Principal,
         @PathVariable @Parameter(description = "챌린지 id", example = "1") challengeId: Long,
-        @RequestBody(required = false) @Valid request: JoinPublicChallengeRequest,
+        @RequestBody @Valid request: JoinPublicChallengeRequest,
     ): ResponseEntity<StringSuccessResponse> {
         challengeService.joinPublicChallenge(
             UserUtility.getUserId(principal),

--- a/src/main/kotlin/com/alloon/alloonserver/api/controller/challenge/request/JoinPublicChallengeRequest.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/api/controller/challenge/request/JoinPublicChallengeRequest.kt
@@ -1,0 +1,18 @@
+package com.alloon.alloonserver.api.controller.challenge.request
+
+import com.alloon.alloonserver.service.challenge.dto.JoinPublicChallengeDto
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.Size
+
+@Schema(description = "공개 챌린지 참여하기 요청 객체")
+data class JoinPublicChallengeRequest(
+
+    @Schema(description = "챌린지 개인목표", example = "열심히 운동하기!!")
+    @field:Size(min = 1, max = 16, message = "개인목표는 1~16자만 가능합니다.")
+    val goal: String?,
+) {
+
+    fun toServiceDto(): JoinPublicChallengeDto {
+        return JoinPublicChallengeDto(goal)
+    }
+}

--- a/src/main/kotlin/com/alloon/alloonserver/common/constant/ExceptionCode.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/common/constant/ExceptionCode.kt
@@ -103,6 +103,7 @@ enum class ExceptionCode(
     EXISTING_USERNAME(CONFLICT, "이미 사용중인 아이디입니다."),
     EXISTING_USER(CONFLICT, "해당 이메일로 이미 가입된 회원이 있습니다."),
     EXISTING_FEED(CONFLICT, "이미 오늘 피드 인증을 완료하였습니다."),
+    EXISTING_CHALLENGE_MEMBER(CONFLICT, "이미 챌린지에 참여한 회원입니다."),
     DELETED_USER(CONFLICT, "이미 탈퇴한 회원입니다."),
 
     /**

--- a/src/main/kotlin/com/alloon/alloonserver/service/challenge/ChallengeService.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/service/challenge/ChallengeService.kt
@@ -265,6 +265,23 @@ class ChallengeService(
             .map { SearchChallengeByHashtagResponse.of(it) }
     }
 
+    @Transactional
+    fun joinPublicChallenge(
+        userId: Long,
+        challengeId: Long,
+        dto: JoinPublicChallengeDto
+    ) {
+        val user = validateUser(userId)
+        val challenge = validateChallenge(challengeId)
+        val challengeMember =
+            challengeMemberRepository.findByUserIdAndChallengeId(userId, challengeId)
+        if (challengeMember != null) {
+            throw CustomException(EXISTING_CHALLENGE_MEMBER)
+        } else {
+            challengeMemberRepository.save(dto.toEntity(user, challenge))
+        }
+    }
+
     private fun validateUser(userId: Long): User {
         return userRepository.find(userId) ?: throw CustomException(USER_NOT_FOUND)
     }

--- a/src/main/kotlin/com/alloon/alloonserver/service/challenge/dto/JoinPublicChallengeDto.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/service/challenge/dto/JoinPublicChallengeDto.kt
@@ -1,0 +1,14 @@
+package com.alloon.alloonserver.service.challenge.dto
+
+import com.alloon.alloonserver.domain.challenge.Challenge
+import com.alloon.alloonserver.domain.challenge.ChallengeMember
+import com.alloon.alloonserver.domain.user.User
+
+data class JoinPublicChallengeDto(
+    val goal: String?
+) {
+
+    fun toEntity(user: User, challenge: Challenge): ChallengeMember {
+        return ChallengeMember(user = user, challenge = challenge, goal = goal, isCreator = false)
+    }
+}


### PR DESCRIPTION
## 📋 이슈 번호
- close #176
  </br>

## 🛠 구현 사항
- 챌린지 개인 목표로 참여하기(개인 목표 없을 시에도 참여하기 가능)
  </br>

## 📚 기타
- 
  </br>