### PR TITLE
[feat] 사용자 챌린지 피드 당일 인증 여부 조회 API

### DIFF
--- a/src/main/kotlin/com/alloon/alloonserver/api/controller/user/UserController.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/api/controller/user/UserController.kt
@@ -176,4 +176,22 @@ class UserController(
 
         return ResponseEntity.ok(response)
     }
+
+    @GetMapping("/challenges/{challengeId}/prove")
+    @Operation(
+        summary = "사용자 챌린지 피드 당일 인증 여부 조회",
+        security = [SecurityRequirement(name = ACCESS_TOKEN_KEY)]
+    )
+    @ApiResponse(responseCode = "200")
+    @ApiErrorResponses([TOKEN_UNAUTHENTICATED, TOKEN_UNAUTHORIZED, CHALLENGE_NOT_FOUND, CHALLENGE_MEMBER_NOT_FOUND])
+    fun findUserChallengeIsProve(
+        principal: Principal,
+        @PathVariable @Parameter(description = "챌린지 id", example = "1") challengeId: Long,
+    ): ResponseEntity<FindUserChallengeIsProveResponse> {
+        val userChallengeIsProve =
+            userService.findUserChallengeIsProve(UserUtility.getUserId(principal), challengeId)
+        val response = FindUserChallengeIsProveResponse.of(userChallengeIsProve)
+
+        return ResponseEntity.ok(response)
+    }
 }

--- a/src/main/kotlin/com/alloon/alloonserver/api/controller/user/response/FindUserChallengeIsProveResponse.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/api/controller/user/response/FindUserChallengeIsProveResponse.kt
@@ -1,0 +1,18 @@
+package com.alloon.alloonserver.api.controller.user.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "사용자 챌린지 인증 여부 응답 객체")
+data class FindUserChallengeIsProveResponse(
+
+    @Schema(description = "챌린지 인증 여부", example = "true")
+    val isProve: Boolean,
+) {
+
+    companion object {
+
+        fun of(isProve: Boolean): FindUserChallengeIsProveResponse {
+            return FindUserChallengeIsProveResponse(isProve)
+        }
+    }
+}

--- a/src/main/kotlin/com/alloon/alloonserver/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/config/SecurityConfig.kt
@@ -43,6 +43,7 @@ class SecurityConfig(
                     "/api/users/feed-history",
                     "/api/users/ended-challenges",
                     "/api/users/my-challenges",
+                    "/api/users/challenges/{challengeId}/prove",
                     "/api/challenges/{challengeId}/info",
                     "/api/challenges/{challengeId}/invitation-code",
                     "/api/challenges/{challengeId}/challenge-members/goal",

--- a/src/main/kotlin/com/alloon/alloonserver/domain/user/custom/UserCustomRepository.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/domain/user/custom/UserCustomRepository.kt
@@ -27,4 +27,6 @@ interface UserCustomRepository {
     fun findEndedChallengesById(userId: Long, pageable: Pageable): Slice<FindUserEndedChallengesDto>
 
     fun findUserChallengesById(userId: Long, pageable: Pageable): Slice<FindUserChallengesDto>
+
+    fun findIsProveByChallengeId(userId: Long, challengeId: Long): Boolean
 }

--- a/src/main/kotlin/com/alloon/alloonserver/domain/user/custom/UserCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/domain/user/custom/UserCustomRepositoryImpl.kt
@@ -293,6 +293,23 @@ class UserCustomRepositoryImpl(
         return SliceImpl(content, pageable, hasNext)
     }
 
+    override fun findIsProveByChallengeId(
+        userId: Long,
+        challengeId: Long
+    ): Boolean {
+        val now = LocalDate.now()
+        return queryFactory.select(feed.isNotNull)
+            .from(feed)
+            .where(
+                feed.challengeMember.user.id.eq(userId),
+                feed.challenge.id.eq(challengeId),
+                feed.createDateTime.year().eq(now.year),
+                feed.createDateTime.month().eq(now.monthValue),
+                feed.createDateTime.dayOfMonth().eq(now.dayOfMonth),
+            )
+            .fetchOne() ?: false
+    }
+
     private fun eqUserId(userId: Long?): BooleanExpression? = userId?.let { user.id.eq(it) }
 
     private fun eqEmail(email: String?): BooleanExpression? = email?.let { contact.email.eq(it) }

--- a/src/main/kotlin/com/alloon/alloonserver/service/user/UserService.kt
+++ b/src/main/kotlin/com/alloon/alloonserver/service/user/UserService.kt
@@ -3,15 +3,16 @@ package com.alloon.alloonserver.service.user
 import com.alloon.alloonserver.api.controller.user.response.FindUserChallengesResponse
 import com.alloon.alloonserver.api.controller.user.response.FindUserEndedChallengesResponse
 import com.alloon.alloonserver.api.controller.user.response.FindUserFeedHistoryResponse
-import com.alloon.alloonserver.common.constant.ExceptionCode.USER_NOT_FOUND
+import com.alloon.alloonserver.common.constant.ExceptionCode.*
 import com.alloon.alloonserver.common.response.CustomException
+import com.alloon.alloonserver.domain.challenge.Challenge
+import com.alloon.alloonserver.domain.challenge.ChallengeMember
+import com.alloon.alloonserver.domain.challenge.ChallengeMemberRepository
+import com.alloon.alloonserver.domain.challenge.ChallengeRepository
 import com.alloon.alloonserver.domain.user.UserRepository
 import com.alloon.alloonserver.service.s3.FolderType.USERS
 import com.alloon.alloonserver.service.s3.S3Service
-import com.alloon.alloonserver.service.user.dto.FindUserChallengeCntDto
-import com.alloon.alloonserver.service.user.dto.FindUserFeedsByDateDto
-import com.alloon.alloonserver.service.user.dto.UserChallengeHistoryDto
-import com.alloon.alloonserver.service.user.dto.UserInfoDto
+import com.alloon.alloonserver.service.user.dto.*
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Slice
 import org.springframework.stereotype.Service
@@ -23,6 +24,8 @@ import java.time.LocalDate
 @Transactional(readOnly = true)
 class UserService(
     private val userRepository: UserRepository,
+    private val challengeRepository: ChallengeRepository,
+    private val challengeMemberRepository: ChallengeMemberRepository,
     private val s3Service: S3Service,
 ) {
 
@@ -81,9 +84,25 @@ class UserService(
             .map { FindUserChallengesResponse.of(it) }
     }
 
+    fun findUserChallengeIsProve(userId: Long, challengeId: Long): Boolean {
+        validateChallenge(challengeId)
+        validateChallengeMember(userId, challengeId)
+        return userRepository.findIsProveByChallengeId(userId, challengeId)
+    }
+
     private fun deleteOriginalImage(imageUrl: String) {
         if (imageUrl.isNotEmpty()) {
             s3Service.deleteImage(imageUrl, USERS)
         }
+    }
+
+    private fun validateChallenge(challengeId: Long): Challenge {
+        return challengeRepository.findInfoById(challengeId)
+            ?: throw CustomException(CHALLENGE_NOT_FOUND)
+    }
+
+    private fun validateChallengeMember(userId: Long, challengeId: Long): ChallengeMember {
+        return challengeMemberRepository.findByUserIdAndChallengeId(userId, challengeId)
+            ?: throw CustomException(CHALLENGE_MEMBER_NOT_FOUND)
     }
 }

--- a/src/test/kotlin/com/alloon/alloonserver/service/user/UserServiceTest.kt
+++ b/src/test/kotlin/com/alloon/alloonserver/service/user/UserServiceTest.kt
@@ -2,6 +2,8 @@ package com.alloon.alloonserver.service.user
 
 import com.alloon.alloonserver.common.constant.ExceptionCode.USER_NOT_FOUND
 import com.alloon.alloonserver.common.response.CustomException
+import com.alloon.alloonserver.domain.challenge.ChallengeMemberRepository
+import com.alloon.alloonserver.domain.challenge.ChallengeRepository
 import com.alloon.alloonserver.domain.user.Contact
 import com.alloon.alloonserver.domain.user.User
 import com.alloon.alloonserver.domain.user.UserRepository
@@ -34,9 +36,12 @@ import java.util.*
 class UserServiceTest {
 
     private val userRepository = mockk<UserRepository>()
+    private val challengeRepository = mockk<ChallengeRepository>()
+    private val challengeMemberRepository = mockk<ChallengeMemberRepository>()
     private val s3Service = mockk<S3Service>()
 
-    private val userService = UserService(userRepository, s3Service)
+    private val userService =
+        UserService(userRepository, challengeRepository, challengeMemberRepository, s3Service)
 
     @DisplayName("사용자 정보 조회를 하면 일치하는 사용자 정보를 반환한다.")
     @Test


### PR DESCRIPTION
## 📋 이슈 번호
- close #182 
  </br>

## 🛠 구현 사항
- 사용자 챌린지 피드 당일 인증 여부 조회 API
  </br>

## 📚 기타
- 
  </br>