### PR TITLE
[feat] 챌린지 인증 피드 존재 여부 API

### DIFF
--- a/src/main/kotlin/com/photi/server/api/controller/challenge/ChallengeController.kt
+++ b/src/main/kotlin/com/photi/server/api/controller/challenge/ChallengeController.kt
@@ -516,4 +516,21 @@ class ChallengeController(
 
         return ResponseEntity.ok(StringSuccessResponse("챌린지 피드 좋아요가 취소되었습니다."))
     }
+
+    @GetMapping("/{challengeId}/feed-existence")
+    @Operation(
+        summary = "챌린지 인증 피드 존재 여부 조회",
+        security = [SecurityRequirement(name = ACCESS_TOKEN_KEY)],
+    )
+    @ApiResponse(responseCode = "200")
+    @ApiErrorResponses([TOKEN_UNAUTHENTICATED, TOKEN_UNAUTHORIZED, CHALLENGE_NOT_FOUND])
+    fun findChallengeHasFeed(
+        principal: Principal,
+        @PathVariable @Parameter(description = "챌린지 id", example = "1") challengeId: Long,
+    ): ResponseEntity<FindChallengeHasFeedResponse> {
+        val hasFeed = challengeService.hasFeedByChallengeId(challengeId)
+        val response = FindChallengeHasFeedResponse.of(hasFeed)
+
+        return ResponseEntity.ok(response)
+    }
 }

--- a/src/main/kotlin/com/photi/server/api/controller/challenge/response/FindChallengeHasFeedResponse.kt
+++ b/src/main/kotlin/com/photi/server/api/controller/challenge/response/FindChallengeHasFeedResponse.kt
@@ -1,0 +1,18 @@
+package com.photi.server.api.controller.challenge.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "챌린지 인증 피드 존재 여부 조회 응답 객체")
+data class FindChallengeHasFeedResponse(
+
+    @Schema(description = "인증 피드 존재 여부", example = "true")
+    val hasFeed: Boolean,
+) {
+
+    companion object {
+
+        fun of(hasFeed: Boolean): FindChallengeHasFeedResponse {
+            return FindChallengeHasFeedResponse(hasFeed)
+        }
+    }
+}

--- a/src/main/kotlin/com/photi/server/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/photi/server/config/SecurityConfig.kt
@@ -54,6 +54,7 @@ class SecurityConfig(
                     "/api/challenges/{challengeId}/feeds/{feedId}/like",
                     "/api/challenges/{challengeId}/feeds/{feedId}/comments",
                     "/api/challenges/{challengeId}/feed-members",
+                    "/api/challenges/{challengeId}/feed-existence",
                     "/api/challenges/feeds/{feedId}/comments",
                     "/api/inquiries",
                     "/api/reports/{targetId}"

--- a/src/main/kotlin/com/photi/server/domain/feed/FeedRepository.kt
+++ b/src/main/kotlin/com/photi/server/domain/feed/FeedRepository.kt
@@ -14,4 +14,6 @@ interface FeedRepository : JpaRepository<Feed, Long>, FeedCustomRepository {
     ): Boolean
 
     fun findByIdAndChallengeMemberId(feedId: Long, challengeMemberId: Long?): Feed?
+
+    fun existsByChallengeId(id: Long): Boolean
 }

--- a/src/main/kotlin/com/photi/server/service/challenge/ChallengeService.kt
+++ b/src/main/kotlin/com/photi/server/service/challenge/ChallengeService.kt
@@ -367,6 +367,11 @@ class ChallengeService(
         feed.decreaseLikeCnt()
     }
 
+    fun hasFeedByChallengeId(challengeId: Long): Boolean {
+        validateChallenge(challengeId)
+        return feedRepository.existsByChallengeId(challengeId)
+    }
+
     private fun validateUser(userId: Long): User {
         return userRepository.find(userId) ?: throw CustomException(USER_NOT_FOUND)
     }


### PR DESCRIPTION
## 📋 이슈 번호
- close #191 
  </br>

## 🛠 구현 사항
- 챌린지 인증 피드 존재 여부 조회
  </br>

## 📚 기타
- 
  </br>