### PR TITLE
[feat] 사용자 피드 인증 횟수 모아보기 조회 API 수정

### DIFF
--- a/src/main/kotlin/com/photi/server/api/controller/user/response/FindUserFeedHistoryResponse.kt
+++ b/src/main/kotlin/com/photi/server/api/controller/user/response/FindUserFeedHistoryResponse.kt
@@ -21,6 +21,9 @@ data class FindUserFeedHistoryResponse(
 
     @Schema(description = "챌린지 이름", example = "신나게 하는 러닝 챌린지")
     val name: String,
+
+    @Schema(description = "챌린지 초대코드", example = "478DS")
+    val invitationCode: String,
 ) {
 
     companion object {
@@ -31,7 +34,8 @@ data class FindUserFeedHistoryResponse(
                 feedHistory.challengeId,
                 feedHistory.imageUrl,
                 feedHistory.createdDate.toLocalDate(),
-                feedHistory.name
+                feedHistory.name,
+                feedHistory.invitationCode,
             )
         }
     }

--- a/src/main/kotlin/com/photi/server/common/util/CodeUtility.kt
+++ b/src/main/kotlin/com/photi/server/common/util/CodeUtility.kt
@@ -6,18 +6,22 @@ class CodeUtility {
 
     companion object {
 
+        private const val EMPTY_CHARACTER = ""
+
         fun getVerificationCode(): String {
             return (0..9).toList()
                 .shuffled(Random(System.currentTimeMillis()))
                 .take(4)
-                .joinToString("")
+                .joinToString(EMPTY_CHARACTER)
         }
 
-        fun getInvitationCode(): String {
+        fun getInvitationCode(isPublic: Boolean): String {
             val range = (0..9) + ('A'..'Z')
-            return range.shuffled(Random(System.currentTimeMillis()))
-                .take(5)
-                .joinToString("")
+            return if (!isPublic) {
+                range.shuffled(Random(System.currentTimeMillis()))
+                    .take(5)
+                    .joinToString(EMPTY_CHARACTER)
+            } else EMPTY_CHARACTER
         }
     }
 }

--- a/src/main/kotlin/com/photi/server/domain/user/custom/UserCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/photi/server/domain/user/custom/UserCustomRepositoryImpl.kt
@@ -152,7 +152,8 @@ class UserCustomRepositoryImpl(
                     feed.challenge.id,
                     feed.imageUrl,
                     feed.createDateTime,
-                    feed.challenge.name
+                    feed.challenge.name,
+                    feed.challenge.invitationCode,
                 )
             )
             .from(feed)

--- a/src/main/kotlin/com/photi/server/service/challenge/ChallengeService.kt
+++ b/src/main/kotlin/com/photi/server/service/challenge/ChallengeService.kt
@@ -49,7 +49,7 @@ class ChallengeService(
         val user = validateUser(userId)
         val fileName = s3Service.uploadImage(imageFile, CHALLENGES)
         val imageUrl = s3Service.getImageUrl(fileName)
-        val invitationCode = CodeUtility.getInvitationCode()
+        val invitationCode = CodeUtility.getInvitationCode(dto.isPublic)
 
         val challenge = dto.toEntity(imageUrl, invitationCode)
         val challengeMember = ChallengeMember(user = user, challenge = challenge)

--- a/src/main/kotlin/com/photi/server/service/user/dto/FindUserFeedHistoryDto.kt
+++ b/src/main/kotlin/com/photi/server/service/user/dto/FindUserFeedHistoryDto.kt
@@ -9,4 +9,5 @@ data class FindUserFeedHistoryDto @QueryProjection constructor(
     val imageUrl: String,
     val createdDate: LocalDateTime,
     val name: String,
+    val invitationCode: String,
 )

--- a/src/test/kotlin/com/photi/server/common/util/CodeUtilityTest.kt
+++ b/src/test/kotlin/com/photi/server/common/util/CodeUtilityTest.kt
@@ -29,10 +29,10 @@ class CodeUtilityTest {
         // given
         val randomCode = "ABC12"
         mockkObject(CodeUtility)
-        every { CodeUtility.getInvitationCode() } returns randomCode
+        every { CodeUtility.getInvitationCode(false) } returns randomCode
 
         // when
-        val result = CodeUtility.getInvitationCode()
+        val result = CodeUtility.getInvitationCode(false)
 
         // then
         assertThat(result).isEqualTo(randomCode)

--- a/src/test/kotlin/com/photi/server/service/user/UserServiceTest.kt
+++ b/src/test/kotlin/com/photi/server/service/user/UserServiceTest.kt
@@ -226,8 +226,14 @@ class UserServiceTest {
     fun givenValid_whenFindUserFeedHistory_thenReturn() {
         // given
         val userId = 1L
-        val dto =
-            FindUserFeedHistoryDto(1L, 1L, "https://url.kr/5MhHhD", LocalDateTime.now(), "챌린지 이름")
+        val dto = FindUserFeedHistoryDto(
+            1L,
+            1L,
+            "https://url.kr/5MhHhD",
+            LocalDateTime.now(),
+            "챌린지 이름",
+            "ABC12"
+        )
         val content = listOf(dto, dto, dto)
         val pageable = PageRequest.of(0, 10)
         val hasNext = true


### PR DESCRIPTION
## 📋 이슈 번호
- close #195
  </br>

## 🛠 구현 사항
- 챌린지 초대코드 필드 추가(공개 - 빈 문자열, 비공개 - 초대코드)
- 챌린지 생성 시 공개, 비공개 초대코드 구분
  </br>

## 📚 기타
- 
  </br>