### PR TITLE
[feat] 사용자 챌린지 기록 조회 API 수정

### DIFF
--- a/src/main/kotlin/com/photi/server/api/controller/user/response/UserChallengeHistoryResponse.kt
+++ b/src/main/kotlin/com/photi/server/api/controller/user/response/UserChallengeHistoryResponse.kt
@@ -3,7 +3,7 @@ package com.photi.server.api.controller.user.response
 import com.fasterxml.jackson.annotation.JsonFormat
 import com.photi.server.service.user.dto.UserChallengeHistoryDto
 import io.swagger.v3.oas.annotations.media.Schema
-import java.time.LocalDateTime
+import java.time.LocalDate
 
 @Schema(description = "사용자 챌린지 기록 응답 객체")
 data class UserChallengeHistoryResponse(
@@ -22,7 +22,7 @@ data class UserChallengeHistoryResponse(
 
     @field:JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     @Schema(description = "사용자 회원가입 날짜", example = "2025-06-01")
-    val registerDate: LocalDateTime,
+    val registerDate: LocalDate,
 ) {
 
     companion object {
@@ -33,7 +33,7 @@ data class UserChallengeHistoryResponse(
                 challengeHistory.imageUrl,
                 challengeHistory.feedCnt,
                 challengeHistory.endedChallengeCnt,
-                challengeHistory.registerDate,
+                challengeHistory.registerDate.toLocalDate(),
             )
         }
     }

--- a/src/main/kotlin/com/photi/server/api/controller/user/response/UserChallengeHistoryResponse.kt
+++ b/src/main/kotlin/com/photi/server/api/controller/user/response/UserChallengeHistoryResponse.kt
@@ -1,7 +1,9 @@
 package com.photi.server.api.controller.user.response
 
+import com.fasterxml.jackson.annotation.JsonFormat
 import com.photi.server.service.user.dto.UserChallengeHistoryDto
 import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDateTime
 
 @Schema(description = "사용자 챌린지 기록 응답 객체")
 data class UserChallengeHistoryResponse(
@@ -17,6 +19,10 @@ data class UserChallengeHistoryResponse(
 
     @Schema(description = "사용자 종료된 챌린지 갯수", example = "2")
     val endedChallengeCnt: Int,
+
+    @field:JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+    @Schema(description = "사용자 회원가입 날짜", example = "2025-06-01")
+    val registerDate: LocalDateTime,
 ) {
 
     companion object {
@@ -27,6 +33,7 @@ data class UserChallengeHistoryResponse(
                 challengeHistory.imageUrl,
                 challengeHistory.feedCnt,
                 challengeHistory.endedChallengeCnt,
+                challengeHistory.registerDate,
             )
         }
     }

--- a/src/main/kotlin/com/photi/server/domain/user/custom/UserCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/photi/server/domain/user/custom/UserCustomRepositoryImpl.kt
@@ -78,6 +78,7 @@ class UserCustomRepositoryImpl(
                     user.imageUrl,
                     user.feedCnt,
                     Expressions.constant(endedChallengeCnt),
+                    user.createDateTime,
                 )
             )
             .from(user)

--- a/src/main/kotlin/com/photi/server/service/user/dto/UserChallengeHistoryDto.kt
+++ b/src/main/kotlin/com/photi/server/service/user/dto/UserChallengeHistoryDto.kt
@@ -1,10 +1,12 @@
 package com.photi.server.service.user.dto
 
 import com.querydsl.core.annotations.QueryProjection
+import java.time.LocalDateTime
 
 data class UserChallengeHistoryDto @QueryProjection constructor(
     val username: String,
     val imageUrl: String,
     val feedCnt: Int,
     val endedChallengeCnt: Int,
+    val registerDate: LocalDateTime,
 )

--- a/src/test/kotlin/com/photi/server/service/user/UserServiceTest.kt
+++ b/src/test/kotlin/com/photi/server/service/user/UserServiceTest.kt
@@ -305,7 +305,13 @@ class UserServiceTest {
     }
 
     private fun getUserChallengeHistoryDto(): UserChallengeHistoryDto {
-        return UserChallengeHistoryDto("tester", "https://url.kr/5MhHhD", 99, 2)
+        return UserChallengeHistoryDto(
+            "tester",
+            "https://url.kr/5MhHhD",
+            99,
+            2,
+            LocalDateTime.now()
+        )
     }
 
     private fun getFindUserFeedsByDateDto(): FindUserFeedsByDateDto {


### PR DESCRIPTION
## 📋 이슈 번호
- close #196
  </br>

## 🛠 구현 사항
- 사용자 회원가입 날짜 필드 추가
  </br>

## 📚 기타
- 
  </br>