### PR TITLE
[refactor] 챌린지 피드 삭제 API 수정

### DIFF
--- a/src/main/kotlin/com/photi/server/api/controller/challenge/ChallengeController.kt
+++ b/src/main/kotlin/com/photi/server/api/controller/challenge/ChallengeController.kt
@@ -207,7 +207,7 @@ class ChallengeController(
     @DeleteMapping("/{challengeId}/feeds/{feedId}")
     @Operation(summary = "챌린지 피드 삭제", security = [SecurityRequirement(name = ACCESS_TOKEN_KEY)])
     @ApiResponse(responseCode = "200")
-    @ApiErrorResponses([TOKEN_UNAUTHENTICATED, TOKEN_UNAUTHORIZED, USER_NOT_FOUND, CHALLENGE_MEMBER_NOT_FOUND, CHALLENGE_NOT_FOUND, FEED_NOT_FOUND])
+    @ApiErrorResponses([TOKEN_UNAUTHENTICATED, TOKEN_UNAUTHORIZED, USER_NOT_FOUND, CHALLENGE_MEMBER_NOT_FOUND, CHALLENGE_NOT_FOUND, FEED_CREATOR_FORBIDDEN])
     fun deleteChallengeFeed(
         principal: Principal,
         @PathVariable @Parameter(description = "챌린지 id", example = "1") challengeId: Long,

--- a/src/main/kotlin/com/photi/server/common/constant/ExceptionCode.kt
+++ b/src/main/kotlin/com/photi/server/common/constant/ExceptionCode.kt
@@ -45,6 +45,7 @@ enum class ExceptionCode(
     TOKEN_UNAUTHORIZED(FORBIDDEN, "권한이 없는 요청입니다. 로그인 후에 다시 시도 해주세요."),
     REQUEST_FORBIDDEN(FORBIDDEN, "권한이 없는 요청입니다."),
     CHALLENGE_CREATOR_FORBIDDEN(FORBIDDEN, "챌린지 파티장 권한이 없습니다."),
+    FEED_CREATOR_FORBIDDEN(FORBIDDEN, "피드 삭제 권한이 없습니다."),
 
     /**
      * 404 Not Found

--- a/src/main/kotlin/com/photi/server/service/challenge/ChallengeService.kt
+++ b/src/main/kotlin/com/photi/server/service/challenge/ChallengeService.kt
@@ -170,7 +170,7 @@ class ChallengeService(
         validateChallenge(challengeId)
         val challengeMemberId = validateChallengeMember(userId, challengeId).id
         val feed = feedRepository.findByIdAndChallengeMemberId(feedId, challengeMemberId)
-            ?: throw CustomException(FEED_NOT_FOUND)
+            ?: throw CustomException(FEED_CREATOR_FORBIDDEN)
         val feedComments = feedCommentRepository.findAllByFeedId(feedId)
         val feedLikes = feedLikeRepository.findAllByFeedId(feedId)
 

--- a/src/test/kotlin/com/photi/server/service/challenge/ChallengeServiceTest.kt
+++ b/src/test/kotlin/com/photi/server/service/challenge/ChallengeServiceTest.kt
@@ -450,7 +450,7 @@ class ChallengeServiceTest {
             .isEqualTo(CHALLENGE_MEMBER_NOT_FOUND)
     }
 
-    @DisplayName("등록되지 않은 피드 삭제를 하면 예외가 발생한다.")
+    @DisplayName("권한이 없는 피드 삭제를 하면 예외가 발생한다.")
     @Test
     fun givenNotFoundFeed_whenDeleteChallengeFeed_thenThrow() {
         // given
@@ -473,7 +473,7 @@ class ChallengeServiceTest {
         assertThatThrownBy { challengeService.deleteChallengeFeed(userId, challengeId, feedId) }
             .isInstanceOf(CustomException::class.java)
             .extracting("exceptionCode")
-            .isEqualTo(FEED_NOT_FOUND)
+            .isEqualTo(FEED_CREATOR_FORBIDDEN)
     }
 
     @DisplayName("챌린지 피드 조회를 하면 정렬 기준으로 정렬된 페이징 객체를 반환한다.")


### PR DESCRIPTION
## 📋 이슈 번호
- close #232
  </br>

## 🛠 구현 사항
- 404(존재하지 않는 피드) -> 403(피드 삭제 권한) 에러코드로 변경
  </br>

## 📚 기타
- 
  </br>