### PR TITLE
[refactor] 사용자 피드 인증 횟수 모아보기 조회, 사용자 피드 인증 개별 날짜 조회 API 수정

### DIFF
--- a/src/main/kotlin/com/photi/server/api/controller/user/response/FindUserFeedHistoryResponse.kt
+++ b/src/main/kotlin/com/photi/server/api/controller/user/response/FindUserFeedHistoryResponse.kt
@@ -24,6 +24,9 @@ data class FindUserFeedHistoryResponse(
 
     @Schema(description = "챌린지 초대코드", example = "478DS")
     val invitationCode: String,
+
+    @Schema(description = "탈퇴한 챌린지 여부", example = "true")
+    val isDeleted: Boolean,
 ) {
 
     companion object {
@@ -36,6 +39,7 @@ data class FindUserFeedHistoryResponse(
                 feedHistory.createdDate.toLocalDate(),
                 feedHistory.name,
                 feedHistory.invitationCode,
+                feedHistory.status.isDeleted(),
             )
         }
     }

--- a/src/main/kotlin/com/photi/server/api/controller/user/response/FindUserFeedsByDateResponse.kt
+++ b/src/main/kotlin/com/photi/server/api/controller/user/response/FindUserFeedsByDateResponse.kt
@@ -23,6 +23,9 @@ data class FindUserFeedsByDateResponse(
     @Schema(description = "피드 인증 시간", example = "13:00")
     @field:JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "kk:mm")
     val proveTime: LocalTime,
+
+    @Schema(description = "탈퇴한 챌린지 여부", example = "true")
+    val isDeleted: Boolean,
 ) {
 
     companion object {
@@ -34,6 +37,7 @@ data class FindUserFeedsByDateResponse(
                 feed.imageUrl,
                 feed.name,
                 feed.proveTime.toLocalTime(),
+                feed.status.isDeleted(),
             )
         }
 

--- a/src/main/kotlin/com/photi/server/domain/challenge/ChallengeMemberStatus.kt
+++ b/src/main/kotlin/com/photi/server/domain/challenge/ChallengeMemberStatus.kt
@@ -5,5 +5,7 @@ enum class ChallengeMemberStatus(
 ) {
     PROGRESS("진행중"),
     COMPLETE("완료"),
-    DELETED("탈퇴"),
+    DELETED("탈퇴");
+
+    fun isDeleted() = this == DELETED
 }

--- a/src/main/kotlin/com/photi/server/domain/user/custom/UserCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/photi/server/domain/user/custom/UserCustomRepositoryImpl.kt
@@ -126,6 +126,7 @@ class UserCustomRepositoryImpl(
                     feed.imageUrl,
                     feed.challenge.name,
                     feed.createDateTime,
+                    feed.challengeMember.status,
                 )
             )
             .from(feed)
@@ -155,15 +156,13 @@ class UserCustomRepositoryImpl(
                     feed.createDateTime,
                     feed.challenge.name,
                     feed.challenge.invitationCode,
+                    feed.challengeMember.status,
                 )
             )
             .from(feed)
             .join(feed.challenge)
             .join(feed.challengeMember.user)
-            .where(
-                feed.challengeMember.user.id.eq(userId),
-                feed.challengeMember.status.eq(PROGRESS),
-            )
+            .where(feed.challengeMember.user.id.eq(userId))
             .orderBy(feed.createDateTime.desc())
             .offset(pageable.offset)
             .limit(pageSize + 1L)

--- a/src/main/kotlin/com/photi/server/service/user/dto/FindUserFeedHistoryDto.kt
+++ b/src/main/kotlin/com/photi/server/service/user/dto/FindUserFeedHistoryDto.kt
@@ -1,5 +1,6 @@
 package com.photi.server.service.user.dto
 
+import com.photi.server.domain.challenge.ChallengeMemberStatus
 import com.querydsl.core.annotations.QueryProjection
 import java.time.LocalDateTime
 
@@ -10,4 +11,5 @@ data class FindUserFeedHistoryDto @QueryProjection constructor(
     val createdDate: LocalDateTime,
     val name: String,
     val invitationCode: String,
+    val status: ChallengeMemberStatus,
 )

--- a/src/main/kotlin/com/photi/server/service/user/dto/FindUserFeedsByDateDto.kt
+++ b/src/main/kotlin/com/photi/server/service/user/dto/FindUserFeedsByDateDto.kt
@@ -1,5 +1,6 @@
 package com.photi.server.service.user.dto
 
+import com.photi.server.domain.challenge.ChallengeMemberStatus
 import com.querydsl.core.annotations.QueryProjection
 import java.time.LocalDateTime
 
@@ -9,4 +10,5 @@ data class FindUserFeedsByDateDto @QueryProjection constructor(
     val imageUrl: String,
     val name: String,
     val proveTime: LocalDateTime,
+    val status: ChallengeMemberStatus,
 )

--- a/src/test/kotlin/com/photi/server/service/user/UserServiceTest.kt
+++ b/src/test/kotlin/com/photi/server/service/user/UserServiceTest.kt
@@ -3,6 +3,7 @@ package com.photi.server.service.user
 import com.photi.server.common.constant.ExceptionCode.USER_NOT_FOUND
 import com.photi.server.common.response.CustomException
 import com.photi.server.domain.challenge.ChallengeMemberRepository
+import com.photi.server.domain.challenge.ChallengeMemberStatus
 import com.photi.server.domain.challenge.ChallengeRepository
 import com.photi.server.domain.user.Contact
 import com.photi.server.domain.user.User
@@ -232,7 +233,8 @@ class UserServiceTest {
             "https://url.kr/5MhHhD",
             LocalDateTime.now(),
             "챌린지 이름",
-            "ABC12"
+            "ABC12",
+            ChallengeMemberStatus.DELETED,
         )
         val content = listOf(dto, dto, dto)
         val pageable = PageRequest.of(0, 10)
@@ -326,7 +328,8 @@ class UserServiceTest {
             1L,
             "https://url.kr/5MhHhD",
             "챌린지 이름",
-            LocalDateTime.of(2025, 6, 3, 13, 0)
+            LocalDateTime.of(2025, 6, 3, 13, 0),
+            ChallengeMemberStatus.PROGRESS,
         )
     }
 


### PR DESCRIPTION
## 📋 이슈 번호
- close #239 
  </br>

## 🛠 구현 사항
- 사용자 피드 인증 횟수 모아보기 조회 API 조건 수정
- 응답에 탈퇴한 챌린지 여부(isDeleted) 필드 추가
  </br>

## 📚 기타
- 
  </br>