### PR TITLE
[fix] 사용자 종료된 챌린지 조회 API 수정

### DIFF
--- a/src/main/kotlin/com/photi/server/domain/user/custom/UserCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/photi/server/domain/user/custom/UserCustomRepositoryImpl.kt
@@ -199,7 +199,8 @@ class UserCustomRepositoryImpl(
             .join(challengeMember.challenge)
             .where(
                 challengeMember.user.id.eq(userId),
-                challengeMember.challenge.serviceStatus.eq(END)
+                challengeMember.challenge.serviceStatus.eq(END),
+                challengeMember.status.eq(PROGRESS),
             )
             .orderBy(challengeMember.challenge.endDate.desc())
             .offset(pageable.offset)


### PR DESCRIPTION
## 📋 이슈 번호
- close #238 
  </br>

## 🛠 구현 사항
- 탈퇴한 챌린지 다시 참여하기 시 발생하는 문제
- 중복 조회 조건 수정
  </br>

## 📚 기타
- 
  </br>