### PR TITLE
[refactor] 사용자 참여 중인 챌린지 조회, 사용자 참여 중인 챌린지 갯수 조회 API 수정

### DIFF
--- a/src/main/kotlin/com/photi/server/domain/user/custom/UserCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/photi/server/domain/user/custom/UserCustomRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package com.photi.server.domain.user.custom
 
+import com.photi.server.domain.base.ServiceStatus.ACTIVE
 import com.photi.server.domain.base.ServiceStatus.END
 import com.photi.server.domain.challenge.ChallengeMemberStatus
 import com.photi.server.domain.challenge.ChallengeMemberStatus.PROGRESS
@@ -108,7 +109,11 @@ class UserCustomRepositoryImpl(
             .select(challengeMember.count())
             .from(challengeMember)
             .join(challengeMember.user)
-            .where(challengeMember.user.id.eq(userId), eqChallengeMemberStatus(PROGRESS))
+            .where(
+                challengeMember.user.id.eq(userId),
+                eqChallengeMemberStatus(PROGRESS),
+                challengeMember.challenge.serviceStatus.eq(ACTIVE),
+            )
             .fetchOne()?.toInt() ?: 0
 
         return queryFactory
@@ -250,7 +255,11 @@ class UserCustomRepositoryImpl(
             .from(challengeMember)
             .join(challengeMember.challenge)
             .join(challengeMember.user)
-            .where(challengeMember.user.id.eq(userId), eqChallengeMemberStatus(PROGRESS))
+            .where(
+                challengeMember.user.id.eq(userId),
+                eqChallengeMemberStatus(PROGRESS),
+                challengeMember.challenge.serviceStatus.eq(ACTIVE),
+            )
             .orderBy(challengeMember.challenge.proveTime.asc())
             .offset(pageable.offset)
             .limit(pageSize + 1L)


### PR DESCRIPTION
## 📋 이슈 번호
- close #244 
  </br>

## 🛠 구현 사항
- 종료된 챌린지는 조회되지 않도록 수정
  </br>

## 📚 기타
- 
  </br>