### PR TITLE
[fix] 회원 탈퇴 후 재가입 로직 수정

### DIFF
--- a/docker/init.sql
+++ b/docker/init.sql
@@ -43,6 +43,8 @@ CREATE TABLE users
     contact_id            BIGINT       NOT NULL,
     feed_cnt              INT          NOT NULL,
     challenge_cnt         INT          NOT NULL,
+    is_deleted            BOOLEAN      NOT NULL,
+    deleted_date          TIMESTAMP(6) NULL,
     CONSTRAINT fk_user_contact FOREIGN KEY (contact_id) REFERENCES contact (contact_id),
     CONSTRAINT uq_users UNIQUE (username)
 );
@@ -364,24 +366,24 @@ VALUES ('photi.aos@gmail.com', 1234, true, false, NOW(), NOW(), null),
 
 -- user 테이블
 INSERT INTO users (username, password, image_url, temporary_password_yn, create_date_time,
-                   update_date_time, contact_id, feed_cnt, challenge_cnt)
+                   update_date_time, contact_id, feed_cnt, challenge_cnt, is_deleted, deleted_date)
 VALUES ('user1', '$2a$10$KcNHY41JcvJd2OGnWmC0bek8qT6XiEE11LeHsOfElgj6bFLYOgGay',
         'https://photi-bucket-1.s3.ap-northeast-2.amazonaws.com/challenges/examples/img_cover_health.jpg',
-        FALSE, NOW(), NOW(), 1, 16, 20),
+        FALSE, NOW(), NOW(), 1, 16, 20, false, null),
        ('user2', '$2a$10$rnp2AMAt4gsvcdxGlGH4UeXLLE2chDTX4aSptgILLUBNaC1ZISGZK',
         'https://photi-bucket-1.s3.ap-northeast-2.amazonaws.com/challenges/examples/img_cover_lucky.jpg',
-        FALSE, NOW(), NOW(), 2, 2, 20),
+        FALSE, NOW(), NOW(), 2, 2, 20, false, null),
        ('user3', '$2a$10$VOCyMnl8u5sXLJDfgDGlvOoxcUesiULBDOkzebTRavhGXlY63B3qi',
         'https://photi-bucket-1.s3.ap-northeast-2.amazonaws.com/challenges/examples/img_cover_photo.jpg',
-        FALSE, NOW(), NOW(), 3, 10, 10),
+        FALSE, NOW(), NOW(), 3, 10, 10, false, null),
        ('user4', '$2a$10$ttevy3H13u6UEbYCDjWOjOImZJKA6SDzNb1rcWcdc.CmQlY4qy8R.',
         'https://photi-bucket-1.s3.ap-northeast-2.amazonaws.com/challenges/examples/img_cover_study.jpg',
-        FALSE, NOW(), NOW(), 4, 0, 15),
+        FALSE, NOW(), NOW(), 4, 0, 15, false, null),
        ('user5', '$2a$10$TMgFmiij5j0NfpOcUyUjtOrbQmBrdKwI/dfzXWI2haHnVcvMD8Vfq',
         'https://photi-bucket-1.s3.ap-northeast-2.amazonaws.com/challenges/examples/img_running.jpg',
-        FALSE, NOW(), NOW(), 5, 8, 10);
+        FALSE, NOW(), NOW(), 5, 8, 10, false, null);
 INSERT INTO users (username, password, image_url, temporary_password_yn, create_date_time,
-                   update_date_time, contact_id, feed_cnt, challenge_cnt)
+                   update_date_time, contact_id, feed_cnt, challenge_cnt, is_deleted, deleted_date)
 SELECT 'user' || gs.i                                                AS username,
        '$2a$10$' || substr(md5(random()::TEXT), 1, 53)               AS password,
        image_urls[CEIL(RANDOM() * ARRAY_LENGTH(image_urls, 1))::INT] AS image_url,
@@ -390,7 +392,9 @@ SELECT 'user' || gs.i                                                AS username
        NOW()                                                         AS update_date_time,
        gs.i                                                          AS contact_id,
        FLOOR(RANDOM() * 20)                                          AS feed_cnt,
-       FLOOR(RANDOM() * 20)                                          AS challenge_cnt
+       FLOOR(RANDOM() * 20)                                          AS challenge_cnt,
+       false                                                         AS is_deleted,
+       null                                                          AS deleted_date
 FROM generate_series(6, 30) AS gs(i)
          CROSS JOIN LATERAL (
     SELECT ARRAY [
@@ -404,13 +408,13 @@ FROM generate_series(6, 30) AS gs(i)
     ) img_array;
 
 INSERT INTO users (username, password, image_url, temporary_password_yn, create_date_time,
-                   update_date_time, contact_id, feed_cnt, challenge_cnt)
+                   update_date_time, contact_id, feed_cnt, challenge_cnt, is_deleted, deleted_date)
 VALUES ('photi_aos', '$2a$10$IyhRXXoibA7zeoq5IMYWMea1kRnt7BX2qzRmQ8Sn0iQosmSyBTjWa',
         'https://photi-bucket-1.s3.ap-northeast-2.amazonaws.com/challenges/examples/img_running.jpg',
-        FALSE, NOW(), NOW(), 31, 0, 0),
+        FALSE, NOW(), NOW(), 31, 0, 0, false, null),
        ('photi_ios', '$2a$10$QyNEaU1.Dkj.dZ34rUzZIuGbOMpi5IV3pddCBraW.3ERu0eOPYHS6',
         'https://photi-bucket-1.s3.ap-northeast-2.amazonaws.com/challenges/examples/img_running.jpg',
-        FALSE, NOW(), NOW(), 32, 0, 0);
+        FALSE, NOW(), NOW(), 32, 0, 0, false, null);
 
 -- user_role 테이블
 INSERT INTO user_role (create_date_time, update_date_time, role, user_id)

--- a/src/main/kotlin/com/photi/server/domain/user/User.kt
+++ b/src/main/kotlin/com/photi/server/domain/user/User.kt
@@ -4,6 +4,7 @@ import com.photi.server.common.constant.ExceptionCode.CHALLENGE_LIMIT_EXCEED
 import com.photi.server.common.response.CustomException
 import com.photi.server.domain.base.BaseEntity
 import jakarta.persistence.*
+import java.time.LocalDateTime
 
 @Table(name = "users")
 @Entity
@@ -35,6 +36,12 @@ class User(
 
     @Column(nullable = false)
     var challengeCnt: Int = 0,
+
+    @Column(nullable = false)
+    var isDeleted: Boolean = false,
+
+    @Column(nullable = true)
+    var deletedDate: LocalDateTime? = null,
 ) : BaseEntity() {
 
     fun resetPassword(password: String) {
@@ -69,6 +76,11 @@ class User(
         if (challengeCnt > 0) {
             challengeCnt -= 1
         }
+    }
+
+    fun softDelete() {
+        isDeleted = true
+        deletedDate = LocalDateTime.now()
     }
 
     fun validateChallengeCnt() {

--- a/src/main/kotlin/com/photi/server/domain/user/UserRepository.kt
+++ b/src/main/kotlin/com/photi/server/domain/user/UserRepository.kt
@@ -5,7 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository
 
 interface UserRepository : JpaRepository<User, Long>, UserCustomRepository {
 
-    fun existsByContact(contact: Contact): Boolean
+    fun existsByContactAndIsDeletedFalse(contact: Contact): Boolean
 
     fun existsByUsername(username: String): Boolean
 

--- a/src/main/kotlin/com/photi/server/service/user/AuthService.kt
+++ b/src/main/kotlin/com/photi/server/service/user/AuthService.kt
@@ -40,7 +40,7 @@ class AuthService(
             if (it.isDeleted) {
                 throw CustomException(DELETED_USER)
             }
-            if (userRepository.existsByContact(it)) {
+            if (userRepository.existsByContactAndIsDeletedFalse(it)) {
                 throw CustomException(EXISTING_EMAIL)
             }
             it.changeVerificationCode(verificationCode)
@@ -73,7 +73,7 @@ class AuthService(
 
         if (!contact.verifyYn)
             throw CustomException(EMAIL_VALIDATION_INVALID)
-        if (userRepository.existsByContact(contact))
+        if (userRepository.existsByContactAndIsDeletedFalse(contact))
             throw CustomException(EXISTING_USER)
 
         validateUsername(UserServiceValidateUsernameDto(request.username))
@@ -137,6 +137,7 @@ class AuthService(
         passwordUtility.verifyPassword(dto.password, user.password)
 
         user.contact.softDelete()
+        user.softDelete()
     }
 
     fun findUserDeletedDate(dto: UserDeletedDateDto): FindUserDeletedDateDto {

--- a/src/main/resources/db/migration/V5__add_is_deleted_deleted_date_in_user.sql
+++ b/src/main/resources/db/migration/V5__add_is_deleted_deleted_date_in_user.sql
@@ -1,0 +1,3 @@
+ALTER TABLE users
+    ADD COLUMN is_deleted   BOOLEAN      NOT NULL DEFAULT false,
+    ADD COLUMN deleted_date TIMESTAMP(6) NULL;

--- a/src/test/kotlin/com/photi/server/service/user/AuthServiceTest.kt
+++ b/src/test/kotlin/com/photi/server/service/user/AuthServiceTest.kt
@@ -47,7 +47,7 @@ class AuthServiceTest {
         val dto = ContactServiceSendVerificationDto("tester@photi.com")
 
         every { contactRepository.findByEmail(any()) } returns contact
-        every { userRepository.existsByContact(any()) } returns false
+        every { userRepository.existsByContactAndIsDeletedFalse(any()) } returns false
         every { emailService.sendEmail(any(), any(), any()) } just Runs
 
         // when
@@ -83,7 +83,7 @@ class AuthServiceTest {
         val dto = ContactServiceSendVerificationDto("tester@photi.com")
 
         every { contactRepository.findByEmail(any()) } returns contact
-        every { userRepository.existsByContact(any()) } returns true
+        every { userRepository.existsByContactAndIsDeletedFalse(any()) } returns true
 
         // when & then
         assertThatThrownBy { authService.sendVerificationCode(dto) }
@@ -194,7 +194,7 @@ class AuthServiceTest {
         val userRole = UserRole(1L, user, Role.USER)
 
         every { contactRepository.findByEmail(any()) } returns contact
-        every { userRepository.existsByContact(any()) } returns false
+        every { userRepository.existsByContactAndIsDeletedFalse(any()) } returns false
         every { userRepository.existsByUsername(any()) } returns false
         every { passwordUtility.encryptPassword(any()) } returns password
         every { userTemplateImageRepository.findAll() } returns listOf()
@@ -250,7 +250,7 @@ class AuthServiceTest {
         val dto = getUserServiceRegisterDto()
 
         every { contactRepository.findByEmail(any()) } returns contact
-        every { userRepository.existsByContact(any()) } returns true
+        every { userRepository.existsByContactAndIsDeletedFalse(any()) } returns true
 
         // when & then
         assertThatThrownBy { authService.registerUser(dto) }


### PR DESCRIPTION
## 📋 이슈 번호
- close #257 
  </br>

## 🛠 구현 사항
- user 테이블 - isDeleted, deletedDate 필드 추가
- 회원가입, 이메일 인증코드 전송 API 예외 - 삭제되지 않은 사용자만 조회되도록 레포지토리 메소드 수정
- 회원 탈퇴 API - user softDelete 추가
- user 테이블 필드 추가 sql 생성
  </br>

## 📚 기타
- 
  </br>