### PR TITLE
[feat] 카카오, 구글, 애플 회원가입 및 로그인 구현

### DIFF
--- a/docker/init.sql
+++ b/docker/init.sql
@@ -20,7 +20,9 @@ CREATE TABLE users
 (
     user_id                 BIGSERIAL PRIMARY KEY,
     email                   VARCHAR(100) NOT NULL,
-    authentication_code     VARCHAR(6)   NOT NULL,
+    provider                VARCHAR(15)  NULL,
+    sub                     VARCHAR(255) NULL,
+    authentication_code     VARCHAR(6)   NULL,
     is_authenticated        BOOLEAN      NOT NULL,
     username                VARCHAR(20)  NULL,
     password                VARCHAR(255) NULL,
@@ -29,7 +31,7 @@ CREATE TABLE users
     deleted_date            TIMESTAMP(6) NULL,
     created_date_time       TIMESTAMP(6) NULL,
     last_modified_date_time TIMESTAMP(6) NULL,
-    CONSTRAINT uq_email UNIQUE (email),
+    CONSTRAINT uq_user_provider_sub UNIQUE (provider, sub),
     CONSTRAINT uq_username UNIQUE (username)
 );
 

--- a/photi-apis/enduser/build.gradle.kts
+++ b/photi-apis/enduser/build.gradle.kts
@@ -1,3 +1,9 @@
+dependencyManagement {
+    imports {
+        mavenBom("org.springframework.cloud:spring-cloud-dependencies:2024.0.0")
+    }
+}
+
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-validation")
@@ -5,6 +11,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-mail")
     implementation("org.springframework.boot:spring-boot-starter-thymeleaf")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
+    implementation("org.springframework.cloud:spring-cloud-starter-openfeign")
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.13")
     implementation("io.jsonwebtoken:jjwt-api:0.13.0")
     implementation("io.micrometer:micrometer-registry-prometheus")

--- a/photi-apis/enduser/src/main/kotlin/com/photi/apis/enduser/common/exception/CustomExceptionHandler.kt
+++ b/photi-apis/enduser/src/main/kotlin/com/photi/apis/enduser/common/exception/CustomExceptionHandler.kt
@@ -3,6 +3,7 @@ package com.photi.apis.enduser.common.exception
 import com.photi.apis.enduser.common.exception.dto.ErrorResponse
 import com.photi.core.domain.common.exception.GlobalErrorCode
 import com.photi.core.domain.common.exception.PhotiException
+import com.photi.core.domain.user.exception.UserErrorCode
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.validation.ConstraintViolationException
 import org.springframework.beans.TypeMismatchException
@@ -71,10 +72,18 @@ class CustomExceptionHandler : ResponseEntityExceptionHandler() {
         status: HttpStatusCode,
         request: WebRequest
     ): ResponseEntity<Any>? {
-        val response = ErrorResponse(
-            GlobalErrorCode.DATE_FORMAT_INVALID.name,
-            GlobalErrorCode.DATE_FORMAT_INVALID.message,
-        )
+        val isEnum = ex.requiredType?.isEnum == true
+        val response = if (isEnum) {
+            ErrorResponse(
+                UserErrorCode.OAUTH_PROVIDER_INVALID.name,
+                UserErrorCode.OAUTH_PROVIDER_INVALID.message,
+            )
+        } else {
+            ErrorResponse(
+                GlobalErrorCode.DATE_FORMAT_INVALID.name,
+                GlobalErrorCode.DATE_FORMAT_INVALID.message,
+            )
+        }
         return ResponseEntity.status(BAD_REQUEST).body(response)
     }
 

--- a/photi-apis/enduser/src/main/kotlin/com/photi/apis/enduser/config/InfraConfig.kt
+++ b/photi-apis/enduser/src/main/kotlin/com/photi/apis/enduser/config/InfraConfig.kt
@@ -12,6 +12,9 @@ import org.springframework.context.annotation.Configuration
         PhotiConfigGroup.REDIS,
         PhotiConfigGroup.S3,
         PhotiConfigGroup.ASYNC,
+        PhotiConfigGroup.REDIS_CACHE,
+        PhotiConfigGroup.FEIGN,
+        PhotiConfigGroup.CONFIGURATION_PROPERTIES,
     ]
 )
 class InfraConfig

--- a/photi-apis/enduser/src/main/kotlin/com/photi/apis/enduser/config/oidc/JwtOidcProvider.kt
+++ b/photi-apis/enduser/src/main/kotlin/com/photi/apis/enduser/config/oidc/JwtOidcProvider.kt
@@ -1,0 +1,87 @@
+package com.photi.apis.enduser.config.oidc
+
+import com.photi.core.domain.common.exception.GlobalException
+import com.photi.core.domain.user.dto.OidcPayload
+import com.photi.core.infra.oauth.port.JwtOidcPort
+import io.jsonwebtoken.*
+import org.springframework.stereotype.Component
+import java.math.BigInteger
+import java.security.KeyFactory
+import java.security.PublicKey
+import java.security.spec.RSAPublicKeySpec
+import java.util.*
+
+@Component
+class JwtOidcProvider : JwtOidcPort {
+
+    override fun getKidFromUnsignedIdToken(
+        idToken: String,
+        iss: String,
+        aud: String,
+        nonce: String,
+    ) = getUnsignedIdTokenClaims(idToken, iss, aud, nonce)
+        .header["kid"]
+        .toString()
+
+    override fun getIdTokenPayload(idToken: String, modulus: String, exponent: String): OidcPayload {
+        val claims = getIdTokenClaims(idToken, modulus, exponent)
+        return OidcPayload(
+            claims.issuer,
+            claims.audience.first(),
+            claims.subject,
+            claims["email"].toString(),
+        )
+    }
+
+    private fun getUnsignedIdTokenClaims(
+        idToken: String,
+        iss: String,
+        aud: String,
+        nonce: String,
+    ): Jwt<Header, Claims> {
+        return try {
+            Jwts.parser()
+                .requireIssuer(iss)
+                .requireAudience(aud)
+                .require("nonce", nonce)
+                .build()
+                .parseUnsecuredClaims(getUnsignedIdToken(idToken))
+        } catch (e: ExpiredJwtException) {
+            throw GlobalException.ExpiredTokenException()
+        } catch (e: Exception) {
+            throw GlobalException.InvalidTokenException()
+        }
+    }
+
+    private fun getUnsignedIdToken(idToken: String): String {
+        val splitToken = idToken.split("\\.")
+        if (splitToken.size != 3) {
+            throw GlobalException.InvalidTokenException()
+        }
+        return "${splitToken[0]}.${splitToken[1]}."
+    }
+
+    private fun getIdTokenClaims(idToken: String, modulus: String, exponent: String): Claims {
+        return try {
+            Jwts.parser()
+                .verifyWith(getRsaPublicKey(modulus, exponent))
+                .build()
+                .parseSignedClaims(idToken)
+                .payload
+        } catch (e: ExpiredJwtException) {
+            throw GlobalException.ExpiredTokenException()
+        } catch (e: Exception) {
+            throw GlobalException.InvalidTokenException()
+        }
+    }
+
+    private fun getRsaPublicKey(modulus: String, exponent: String): PublicKey {
+        val keyFactory = KeyFactory.getInstance("RSA")
+        val decodeN = Base64.getUrlDecoder().decode(modulus)
+        val decodeE = Base64.getUrlDecoder().decode(exponent)
+        val n = BigInteger(1, decodeN)
+        val e = BigInteger(1, decodeE)
+        val keySpec = RSAPublicKeySpec(n, e)
+        return keyFactory.generatePublic(keySpec)
+    }
+}

--- a/photi-apis/enduser/src/main/kotlin/com/photi/apis/enduser/config/oidc/JwtOidcProvider.kt
+++ b/photi-apis/enduser/src/main/kotlin/com/photi/apis/enduser/config/oidc/JwtOidcProvider.kt
@@ -1,5 +1,6 @@
 package com.photi.apis.enduser.config.oidc
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.photi.core.domain.common.exception.GlobalException
 import com.photi.core.domain.user.dto.OidcPayload
 import com.photi.core.infra.oauth.port.JwtOidcPort
@@ -12,16 +13,22 @@ import java.security.spec.RSAPublicKeySpec
 import java.util.*
 
 @Component
-class JwtOidcProvider : JwtOidcPort {
+class JwtOidcProvider(
+    private val objectMapper: ObjectMapper,
+) : JwtOidcPort {
 
     override fun getKidFromUnsignedIdToken(
         idToken: String,
         iss: String,
         aud: String,
         nonce: String,
-    ) = getUnsignedIdTokenClaims(idToken, iss, aud, nonce)
-        .header[KID]
-        .toString()
+    ): String {
+        val splitIdToken = getSplitIdToken(idToken)
+        validatePayload(splitIdToken[1], iss, aud, nonce)
+        val headerJson = String(Base64.getUrlDecoder().decode(splitIdToken[0]))
+        val headerMap = objectMapper.readValue(headerJson, Map::class.java)
+        return headerMap[KID].toString()
+    }
 
     override fun getIdTokenPayload(
         idToken: String,
@@ -34,35 +41,27 @@ class JwtOidcProvider : JwtOidcPort {
             claims.audience.first(),
             claims.subject,
             claims[EMAIL].toString(),
+            claims[PICTURE].toString(),
         )
     }
 
-    private fun getUnsignedIdTokenClaims(
-        idToken: String,
-        iss: String,
-        aud: String,
-        nonce: String,
-    ): Jwt<Header, Claims> {
-        return try {
-            Jwts.parser()
-                .requireIssuer(iss)
-                .requireAudience(aud)
-                .require(NONCE, nonce)
-                .build()
-                .parseUnsecuredClaims(getUnsignedIdToken(idToken))
-        } catch (e: ExpiredJwtException) {
-            throw GlobalException.ExpiredTokenException()
-        } catch (e: Exception) {
-            throw GlobalException.InvalidTokenException()
-        }
-    }
-
-    private fun getUnsignedIdToken(idToken: String): String {
-        val splitToken = idToken.split("\\.")
+    private fun getSplitIdToken(idToken: String): List<String> {
+        val splitToken = idToken.split(".")
         if (splitToken.size != 3) {
             throw GlobalException.InvalidTokenException()
         }
-        return "${splitToken[0]}.${splitToken[1]}."
+        return splitToken
+    }
+
+    private fun validatePayload(payload: String, iss: String, aud: String, nonce: String) {
+        val payloadJson = String(Base64.getUrlDecoder().decode(payload))
+        val payloadMap = objectMapper.readValue(payloadJson, Map::class.java)
+        if (payloadMap[ISS] != iss || payloadMap[AUD] != aud || payloadMap[NONCE] != nonce) {
+            throw GlobalException.InvalidTokenException()
+        }
+        val exp = (payloadMap[EXP] as? Number)?.toLong()
+            ?: throw GlobalException.InvalidTokenException()
+        if (Date().time / 1000 > exp) throw GlobalException.ExpiredTokenException()
     }
 
     private fun getIdTokenClaims(idToken: String, modulus: String, exponent: String): Claims {
@@ -91,7 +90,11 @@ class JwtOidcProvider : JwtOidcPort {
 
     companion object {
         private const val KID = "kid"
+        private const val ISS = "iss"
+        private const val AUD = "aud"
+        private const val EXP = "exp"
         private const val EMAIL = "email"
+        private const val PICTURE = "picture"
         private const val NONCE = "nonce"
         private const val ALGORITHM = "RSA"
     }

--- a/photi-apis/enduser/src/main/kotlin/com/photi/apis/enduser/config/oidc/JwtOidcProvider.kt
+++ b/photi-apis/enduser/src/main/kotlin/com/photi/apis/enduser/config/oidc/JwtOidcProvider.kt
@@ -17,14 +17,9 @@ class JwtOidcProvider(
     private val objectMapper: ObjectMapper,
 ) : JwtOidcPort {
 
-    override fun getKidFromUnsignedIdToken(
-        idToken: String,
-        iss: String,
-        aud: String,
-        nonce: String,
-    ): String {
+    override fun getKidFromUnsignedIdToken(idToken: String, iss: String, aud: String): String {
         val splitIdToken = getSplitIdToken(idToken)
-        validatePayload(splitIdToken[1], iss, aud, nonce)
+        validatePayload(splitIdToken[1], iss, aud)
         val headerJson = String(Base64.getUrlDecoder().decode(splitIdToken[0]))
         val headerMap = objectMapper.readValue(headerJson, Map::class.java)
         return headerMap[KID].toString()
@@ -53,10 +48,10 @@ class JwtOidcProvider(
         return splitToken
     }
 
-    private fun validatePayload(payload: String, iss: String, aud: String, nonce: String) {
+    private fun validatePayload(payload: String, iss: String, aud: String) {
         val payloadJson = String(Base64.getUrlDecoder().decode(payload))
         val payloadMap = objectMapper.readValue(payloadJson, Map::class.java)
-        if (payloadMap[ISS] != iss || payloadMap[AUD] != aud || payloadMap[NONCE] != nonce) {
+        if (payloadMap[ISS] != iss || payloadMap[AUD] != aud) {
             throw GlobalException.InvalidTokenException()
         }
         val exp = (payloadMap[EXP] as? Number)?.toLong()
@@ -95,7 +90,6 @@ class JwtOidcProvider(
         private const val EXP = "exp"
         private const val EMAIL = "email"
         private const val PICTURE = "picture"
-        private const val NONCE = "nonce"
         private const val ALGORITHM = "RSA"
     }
 }

--- a/photi-apis/enduser/src/main/kotlin/com/photi/apis/enduser/config/oidc/JwtOidcProvider.kt
+++ b/photi-apis/enduser/src/main/kotlin/com/photi/apis/enduser/config/oidc/JwtOidcProvider.kt
@@ -20,16 +20,20 @@ class JwtOidcProvider : JwtOidcPort {
         aud: String,
         nonce: String,
     ) = getUnsignedIdTokenClaims(idToken, iss, aud, nonce)
-        .header["kid"]
+        .header[KID]
         .toString()
 
-    override fun getIdTokenPayload(idToken: String, modulus: String, exponent: String): OidcPayload {
+    override fun getIdTokenPayload(
+        idToken: String,
+        modulus: String,
+        exponent: String,
+    ): OidcPayload {
         val claims = getIdTokenClaims(idToken, modulus, exponent)
         return OidcPayload(
             claims.issuer,
             claims.audience.first(),
             claims.subject,
-            claims["email"].toString(),
+            claims[EMAIL].toString(),
         )
     }
 
@@ -43,7 +47,7 @@ class JwtOidcProvider : JwtOidcPort {
             Jwts.parser()
                 .requireIssuer(iss)
                 .requireAudience(aud)
-                .require("nonce", nonce)
+                .require(NONCE, nonce)
                 .build()
                 .parseUnsecuredClaims(getUnsignedIdToken(idToken))
         } catch (e: ExpiredJwtException) {
@@ -76,12 +80,19 @@ class JwtOidcProvider : JwtOidcPort {
     }
 
     private fun getRsaPublicKey(modulus: String, exponent: String): PublicKey {
-        val keyFactory = KeyFactory.getInstance("RSA")
+        val keyFactory = KeyFactory.getInstance(ALGORITHM)
         val decodeN = Base64.getUrlDecoder().decode(modulus)
         val decodeE = Base64.getUrlDecoder().decode(exponent)
         val n = BigInteger(1, decodeN)
         val e = BigInteger(1, decodeE)
         val keySpec = RSAPublicKeySpec(n, e)
         return keyFactory.generatePublic(keySpec)
+    }
+
+    companion object {
+        private const val KID = "kid"
+        private const val EMAIL = "email"
+        private const val NONCE = "nonce"
+        private const val ALGORITHM = "RSA"
     }
 }

--- a/photi-apis/enduser/src/main/kotlin/com/photi/apis/enduser/controller/oauth/OAuthController.kt
+++ b/photi-apis/enduser/src/main/kotlin/com/photi/apis/enduser/controller/oauth/OAuthController.kt
@@ -1,0 +1,42 @@
+package com.photi.apis.enduser.controller.oauth
+
+import com.photi.apis.enduser.common.exception.UserApiErrorResponses
+import com.photi.apis.enduser.config.security.JwtTokenProvider
+import com.photi.apis.enduser.controller.auth.dto.response.SignUpResponse
+import com.photi.apis.enduser.controller.oauth.request.OAuthSignUpRequest
+import com.photi.core.domain.user.exception.UserErrorCode.*
+import com.photi.core.domain.user.model.RoleType
+import com.photi.core.domain.user.service.OAuthService
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus.CREATED
+import org.springframework.http.ResponseEntity
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.*
+
+@Validated
+@RestController
+@RequestMapping("/api/v2/oauth")
+@Tag(name = "OAuth", description = "OAuth API")
+class OAuthController(
+    private val oAuthService: OAuthService,
+    private val jwtTokenProvider: JwtTokenProvider,
+) {
+
+    @PostMapping("/kakao/signup")
+    @Operation(summary = "카카오 회원가입")
+    @ApiResponse(responseCode = "201")
+    @UserApiErrorResponses([EXISTING_USER])
+    fun kakaoSignUp(
+        @RequestParam("id_token") @Parameter(description = "ID 토큰") idToken: String,
+        @RequestBody @Valid request: OAuthSignUpRequest,
+    ): ResponseEntity<SignUpResponse> {
+        val signUpUser = oAuthService.kakaoSignUp(idToken, request.toServiceDto())
+        val response = SignUpResponse.of(signUpUser)
+        val headers = jwtTokenProvider.createToken(response.userId, RoleType.USER)
+        return ResponseEntity.status(CREATED).headers(headers).body(response)
+    }
+}

--- a/photi-apis/enduser/src/main/kotlin/com/photi/apis/enduser/controller/oauth/OAuthController.kt
+++ b/photi-apis/enduser/src/main/kotlin/com/photi/apis/enduser/controller/oauth/OAuthController.kt
@@ -6,6 +6,7 @@ import com.photi.apis.enduser.controller.auth.dto.response.LoginResponse
 import com.photi.apis.enduser.controller.auth.dto.response.SignUpResponse
 import com.photi.apis.enduser.controller.oauth.request.OAuthSignUpRequest
 import com.photi.core.domain.user.exception.UserErrorCode.*
+import com.photi.core.domain.user.model.OAuthProviderType
 import com.photi.core.domain.user.model.RoleType
 import com.photi.core.domain.user.model.RoleType.Companion.getRole
 import com.photi.core.domain.user.service.OAuthService
@@ -29,26 +30,30 @@ class OAuthController(
     private val jwtTokenProvider: JwtTokenProvider,
 ) {
 
-    @PostMapping("/kakao/signup")
-    @Operation(summary = "카카오 회원가입")
+    @PostMapping("/{provider}/signup")
+    @Operation(summary = "OAuth 회원가입")
     @ApiResponse(responseCode = "201")
     @UserApiErrorResponses([EXISTING_USER])
-    fun kakaoSignUp(
+    fun signUp(
+        @PathVariable provider: OAuthProviderType,
         @RequestParam("id_token") @Parameter(description = "ID 토큰") idToken: String,
         @RequestBody @Valid request: OAuthSignUpRequest,
     ): ResponseEntity<SignUpResponse> {
-        val signUpUser = oAuthService.kakaoSignUp(idToken, request.toServiceDto())
+        val signUpUser = oAuthService.signUp(provider, idToken, request.toServiceDto())
         val response = SignUpResponse.of(signUpUser)
         val headers = jwtTokenProvider.createToken(response.userId, RoleType.USER)
         return ResponseEntity.status(CREATED).headers(headers).body(response)
     }
 
-    @GetMapping("/kakao/login")
-    @Operation(summary = "카카오 로그인")
+    @GetMapping("/{provider}/login")
+    @Operation(summary = "OAuth 로그인")
     @ApiResponse(responseCode = "200")
     @UserApiErrorResponses([USER_NOT_FOUND, DELETED_USER])
-    fun kakaoLogin(@RequestParam("id_token") @Parameter(description = "ID 토큰") idToken: String): ResponseEntity<LoginResponse> {
-        val loginUser = oAuthService.kakaoLogin(idToken)
+    fun login(
+        @PathVariable provider: OAuthProviderType,
+        @RequestParam("id_token") @Parameter(description = "ID 토큰") idToken: String,
+    ): ResponseEntity<LoginResponse> {
+        val loginUser = oAuthService.login(provider, idToken)
         val response = LoginResponse.of(loginUser)
         val headers = jwtTokenProvider.createToken(response.userId, getRole(response.username))
         return ResponseEntity.status(OK).headers(headers).body(response)

--- a/photi-apis/enduser/src/main/kotlin/com/photi/apis/enduser/controller/oauth/OAuthController.kt
+++ b/photi-apis/enduser/src/main/kotlin/com/photi/apis/enduser/controller/oauth/OAuthController.kt
@@ -1,10 +1,13 @@
 package com.photi.apis.enduser.controller.oauth
 
+import com.photi.apis.enduser.common.exception.GlobalApiErrorResponses
 import com.photi.apis.enduser.common.exception.UserApiErrorResponses
 import com.photi.apis.enduser.config.security.JwtTokenProvider
 import com.photi.apis.enduser.controller.auth.dto.response.LoginResponse
 import com.photi.apis.enduser.controller.auth.dto.response.SignUpResponse
 import com.photi.apis.enduser.controller.oauth.request.OAuthSignUpRequest
+import com.photi.core.domain.common.exception.GlobalErrorCode.EXPIRED_TOKEN
+import com.photi.core.domain.common.exception.GlobalErrorCode.INVALID_TOKEN
 import com.photi.core.domain.user.exception.UserErrorCode.*
 import com.photi.core.domain.user.model.OAuthProviderType
 import com.photi.core.domain.user.model.RoleType
@@ -34,6 +37,7 @@ class OAuthController(
     @Operation(summary = "OAuth 회원가입")
     @ApiResponse(responseCode = "201")
     @UserApiErrorResponses([EXISTING_USER])
+    @GlobalApiErrorResponses([INVALID_TOKEN, EXPIRED_TOKEN])
     fun signUp(
         @PathVariable provider: OAuthProviderType,
         @RequestParam("id_token") @Parameter(description = "ID 토큰") idToken: String,
@@ -49,6 +53,7 @@ class OAuthController(
     @Operation(summary = "OAuth 로그인")
     @ApiResponse(responseCode = "200")
     @UserApiErrorResponses([USER_NOT_FOUND, DELETED_USER])
+    @GlobalApiErrorResponses([INVALID_TOKEN, EXPIRED_TOKEN])
     fun login(
         @PathVariable provider: OAuthProviderType,
         @RequestParam("id_token") @Parameter(description = "ID 토큰") idToken: String,

--- a/photi-apis/enduser/src/main/kotlin/com/photi/apis/enduser/controller/oauth/OAuthController.kt
+++ b/photi-apis/enduser/src/main/kotlin/com/photi/apis/enduser/controller/oauth/OAuthController.kt
@@ -2,10 +2,12 @@ package com.photi.apis.enduser.controller.oauth
 
 import com.photi.apis.enduser.common.exception.UserApiErrorResponses
 import com.photi.apis.enduser.config.security.JwtTokenProvider
+import com.photi.apis.enduser.controller.auth.dto.response.LoginResponse
 import com.photi.apis.enduser.controller.auth.dto.response.SignUpResponse
 import com.photi.apis.enduser.controller.oauth.request.OAuthSignUpRequest
 import com.photi.core.domain.user.exception.UserErrorCode.*
 import com.photi.core.domain.user.model.RoleType
+import com.photi.core.domain.user.model.RoleType.Companion.getRole
 import com.photi.core.domain.user.service.OAuthService
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
@@ -13,6 +15,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus.CREATED
+import org.springframework.http.HttpStatus.OK
 import org.springframework.http.ResponseEntity
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.*
@@ -38,5 +41,16 @@ class OAuthController(
         val response = SignUpResponse.of(signUpUser)
         val headers = jwtTokenProvider.createToken(response.userId, RoleType.USER)
         return ResponseEntity.status(CREATED).headers(headers).body(response)
+    }
+
+    @GetMapping("/kakao/login")
+    @Operation(summary = "카카오 로그인")
+    @ApiResponse(responseCode = "200")
+    @UserApiErrorResponses([USER_NOT_FOUND, DELETED_USER])
+    fun kakaoLogin(@RequestParam("id_token") @Parameter(description = "ID 토큰") idToken: String): ResponseEntity<LoginResponse> {
+        val loginUser = oAuthService.kakaoLogin(idToken)
+        val response = LoginResponse.of(loginUser)
+        val headers = jwtTokenProvider.createToken(response.userId, getRole(response.username))
+        return ResponseEntity.status(OK).headers(headers).body(response)
     }
 }

--- a/photi-apis/enduser/src/main/kotlin/com/photi/apis/enduser/controller/oauth/OAuthProviderConverter.kt
+++ b/photi-apis/enduser/src/main/kotlin/com/photi/apis/enduser/controller/oauth/OAuthProviderConverter.kt
@@ -10,7 +10,7 @@ class OAuthProviderConverter : Converter<String, OAuthProviderType> {
 
     override fun convert(source: String): OAuthProviderType? {
         return try {
-            OAuthProviderType.valueOf(source.lowercase())
+            OAuthProviderType.valueOf(source.uppercase())
         } catch (e: IllegalArgumentException) {
             throw UserException.InvalidOAuthProviderException()
         }

--- a/photi-apis/enduser/src/main/kotlin/com/photi/apis/enduser/controller/oauth/OAuthProviderConverter.kt
+++ b/photi-apis/enduser/src/main/kotlin/com/photi/apis/enduser/controller/oauth/OAuthProviderConverter.kt
@@ -1,0 +1,18 @@
+package com.photi.apis.enduser.controller.oauth
+
+import com.photi.core.domain.user.exception.UserException
+import com.photi.core.domain.user.model.OAuthProviderType
+import org.springframework.core.convert.converter.Converter
+import org.springframework.stereotype.Component
+
+@Component
+class OAuthProviderConverter : Converter<String, OAuthProviderType> {
+
+    override fun convert(source: String): OAuthProviderType? {
+        return try {
+            OAuthProviderType.valueOf(source.lowercase())
+        } catch (e: IllegalArgumentException) {
+            throw UserException.InvalidOAuthProviderException()
+        }
+    }
+}

--- a/photi-apis/enduser/src/main/kotlin/com/photi/apis/enduser/controller/oauth/request/OAuthSignUpRequest.kt
+++ b/photi-apis/enduser/src/main/kotlin/com/photi/apis/enduser/controller/oauth/request/OAuthSignUpRequest.kt
@@ -1,0 +1,24 @@
+package com.photi.apis.enduser.controller.oauth.request
+
+import com.photi.core.domain.common.consts.RegexPattern.LOWERCASE_NUMBER_UNDERSCORE
+import com.photi.core.domain.user.dto.OAuthSignUpDto
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Pattern
+import jakarta.validation.constraints.Size
+
+@Schema(description = "OAuth 회원가입 요청 객체")
+data class OAuthSignUpRequest(
+
+    @Schema(description = "아이디", example = "photi")
+    @field:NotBlank(message = "아이디는 필수 입력입니다.")
+    @field:Size(min = 5, max = 20, message = "아이디는 5~20자만 가능합니다.")
+    @field:Pattern(
+        regexp = LOWERCASE_NUMBER_UNDERSCORE,
+        message = "아이디는 소문자 영어, 숫자, 특수문자(_)의 조합으로 입력해 주세요."
+    )
+    val username: String,
+) {
+
+    fun toServiceDto() = OAuthSignUpDto(username)
+}

--- a/photi-core/domain/src/main/kotlin/com/photi/core/domain/common/properties/AppleOAuthProperties.kt
+++ b/photi-core/domain/src/main/kotlin/com/photi/core/domain/common/properties/AppleOAuthProperties.kt
@@ -1,0 +1,9 @@
+package com.photi.core.domain.common.properties
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties("oauth.apple")
+data class AppleOAuthProperties(
+    override val baseUrl: String,
+    override val restApiKey: String,
+) : OAuthProperties

--- a/photi-core/domain/src/main/kotlin/com/photi/core/domain/common/properties/AppleOAuthProperties.kt
+++ b/photi-core/domain/src/main/kotlin/com/photi/core/domain/common/properties/AppleOAuthProperties.kt
@@ -5,5 +5,5 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 @ConfigurationProperties("oauth.apple")
 data class AppleOAuthProperties(
     override val baseUrl: String,
-    override val restApiKey: String,
+    override val nativeAppKey: String,
 ) : OAuthProperties

--- a/photi-core/domain/src/main/kotlin/com/photi/core/domain/common/properties/GoogleOAuthProperties.kt
+++ b/photi-core/domain/src/main/kotlin/com/photi/core/domain/common/properties/GoogleOAuthProperties.kt
@@ -2,8 +2,8 @@ package com.photi.core.domain.common.properties
 
 import org.springframework.boot.context.properties.ConfigurationProperties
 
-@ConfigurationProperties("oauth.kakao")
-data class KakaoOAuthProperties(
+@ConfigurationProperties("oauth.google")
+data class GoogleOAuthProperties(
     override val baseUrl: String,
     override val restApiKey: String,
 ) : OAuthProperties

--- a/photi-core/domain/src/main/kotlin/com/photi/core/domain/common/properties/GoogleOAuthProperties.kt
+++ b/photi-core/domain/src/main/kotlin/com/photi/core/domain/common/properties/GoogleOAuthProperties.kt
@@ -5,5 +5,5 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 @ConfigurationProperties("oauth.google")
 data class GoogleOAuthProperties(
     override val baseUrl: String,
-    override val restApiKey: String,
+    override val nativeAppKey: String,
 ) : OAuthProperties

--- a/photi-core/domain/src/main/kotlin/com/photi/core/domain/common/properties/KakaoOAuthProperties.kt
+++ b/photi-core/domain/src/main/kotlin/com/photi/core/domain/common/properties/KakaoOAuthProperties.kt
@@ -5,5 +5,5 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 @ConfigurationProperties("oauth.kakao")
 data class KakaoOAuthProperties(
     override val baseUrl: String,
-    override val restApiKey: String,
+    override val nativeAppKey: String,
 ) : OAuthProperties

--- a/photi-core/domain/src/main/kotlin/com/photi/core/domain/common/properties/KakaoOAuthProperties.kt
+++ b/photi-core/domain/src/main/kotlin/com/photi/core/domain/common/properties/KakaoOAuthProperties.kt
@@ -1,0 +1,9 @@
+package com.photi.core.domain.common.properties
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties("oauth.kakao")
+data class KakaoOAuthProperties(
+    val baseUrl: String,
+    val restApiKey: String,
+)

--- a/photi-core/domain/src/main/kotlin/com/photi/core/domain/common/properties/OAuthProperties.kt
+++ b/photi-core/domain/src/main/kotlin/com/photi/core/domain/common/properties/OAuthProperties.kt
@@ -1,0 +1,6 @@
+package com.photi.core.domain.common.properties
+
+interface OAuthProperties {
+    val baseUrl: String
+    val restApiKey: String
+}

--- a/photi-core/domain/src/main/kotlin/com/photi/core/domain/common/properties/OAuthProperties.kt
+++ b/photi-core/domain/src/main/kotlin/com/photi/core/domain/common/properties/OAuthProperties.kt
@@ -2,5 +2,5 @@ package com.photi.core.domain.common.properties
 
 interface OAuthProperties {
     val baseUrl: String
-    val restApiKey: String
+    val nativeAppKey: String
 }

--- a/photi-core/domain/src/main/kotlin/com/photi/core/domain/user/dto/OAuthSignUpDto.kt
+++ b/photi-core/domain/src/main/kotlin/com/photi/core/domain/user/dto/OAuthSignUpDto.kt
@@ -8,12 +8,13 @@ data class OAuthSignUpDto(
     val username: String,
 ) {
 
-    fun toEntity(oAuthInfo: OAuthInfo, email: String) =
+    fun toEntity(oAuthInfo: OAuthInfo, email: String, image: String) =
         User(
             email = email,
             oAuthInfo = oAuthInfo,
             username = username,
             role = RoleType.USER,
             isAuthenticated = true,
+            imageUrl = image,
         )
 }

--- a/photi-core/domain/src/main/kotlin/com/photi/core/domain/user/dto/OAuthSignUpDto.kt
+++ b/photi-core/domain/src/main/kotlin/com/photi/core/domain/user/dto/OAuthSignUpDto.kt
@@ -1,0 +1,19 @@
+package com.photi.core.domain.user.dto
+
+import com.photi.core.domain.user.model.OAuthInfo
+import com.photi.core.domain.user.model.RoleType
+import com.photi.core.domain.user.model.User
+
+data class OAuthSignUpDto(
+    val username: String,
+) {
+
+    fun toEntity(oAuthInfo: OAuthInfo, email: String) =
+        User(
+            email = email,
+            oAuthInfo = oAuthInfo,
+            username = username,
+            role = RoleType.USER,
+            isAuthenticated = true,
+        )
+}

--- a/photi-core/domain/src/main/kotlin/com/photi/core/domain/user/dto/OidcPayload.kt
+++ b/photi-core/domain/src/main/kotlin/com/photi/core/domain/user/dto/OidcPayload.kt
@@ -5,4 +5,5 @@ data class OidcPayload(
     val aud: String,
     val sub: String,
     val email: String,
+    val image: String,
 )

--- a/photi-core/domain/src/main/kotlin/com/photi/core/domain/user/dto/OidcPayload.kt
+++ b/photi-core/domain/src/main/kotlin/com/photi/core/domain/user/dto/OidcPayload.kt
@@ -1,0 +1,8 @@
+package com.photi.core.domain.user.dto
+
+data class OidcPayload(
+    val iss: String,
+    val aud: String,
+    val sub: String,
+    val email: String,
+)

--- a/photi-core/domain/src/main/kotlin/com/photi/core/domain/user/exception/UserErrorCode.kt
+++ b/photi-core/domain/src/main/kotlin/com/photi/core/domain/user/exception/UserErrorCode.kt
@@ -31,5 +31,6 @@ enum class UserErrorCode(
         "USERNAME_FORMAT_INVALID",
         "아이디는 소문자 영어, 숫자, 특수문자(_)의 조합으로 입력해 주세요.",
         "아이디는 5~20자만 가능하고, 정규식은 ^[a-z0-9_]+$ 입니다.",
-    );
+    ),
+    OAUTH_PROVIDER_INVALID(BAD_REQUEST, "OAUTH_PROVIDER_INVALID", "지원하지 않는 OAuth Provider 입니다."),
 }

--- a/photi-core/domain/src/main/kotlin/com/photi/core/domain/user/exception/UserException.kt
+++ b/photi-core/domain/src/main/kotlin/com/photi/core/domain/user/exception/UserException.kt
@@ -24,4 +24,6 @@ sealed class UserException(errorCode: UserErrorCode) : PhotiException(errorCode)
     class ExistsUsernameException : UserException(UserErrorCode.EXISTING_USERNAME)
 
     class NotAvailableUsernameException : UserException(UserErrorCode.UNAVAILABLE_USERNAME)
+
+    class InvalidOAuthProviderException : UserException(UserErrorCode.OAUTH_PROVIDER_INVALID)
 }

--- a/photi-core/domain/src/main/kotlin/com/photi/core/domain/user/model/OAuthInfo.kt
+++ b/photi-core/domain/src/main/kotlin/com/photi/core/domain/user/model/OAuthInfo.kt
@@ -19,5 +19,7 @@ class OAuthInfo(
     companion object {
 
         fun ofKakao(sub: String) = OAuthInfo(OAuthProviderType.KAKAO, sub)
+
+        fun ofGoogle(sub: String) = OAuthInfo(OAuthProviderType.GOOGLE, sub)
     }
 }

--- a/photi-core/domain/src/main/kotlin/com/photi/core/domain/user/model/OAuthInfo.kt
+++ b/photi-core/domain/src/main/kotlin/com/photi/core/domain/user/model/OAuthInfo.kt
@@ -18,6 +18,6 @@ class OAuthInfo(
 
     companion object {
 
-        fun of(provider: OAuthProviderType, sub: String) = OAuthInfo(provider, sub)
+        fun ofKakao(sub: String) = OAuthInfo(OAuthProviderType.KAKAO, sub)
     }
 }

--- a/photi-core/domain/src/main/kotlin/com/photi/core/domain/user/model/OAuthInfo.kt
+++ b/photi-core/domain/src/main/kotlin/com/photi/core/domain/user/model/OAuthInfo.kt
@@ -21,5 +21,7 @@ class OAuthInfo(
         fun ofKakao(sub: String) = OAuthInfo(OAuthProviderType.KAKAO, sub)
 
         fun ofGoogle(sub: String) = OAuthInfo(OAuthProviderType.GOOGLE, sub)
+
+        fun ofApple(sub: String) = OAuthInfo(OAuthProviderType.APPLE, sub)
     }
 }

--- a/photi-core/domain/src/main/kotlin/com/photi/core/domain/user/model/OAuthInfo.kt
+++ b/photi-core/domain/src/main/kotlin/com/photi/core/domain/user/model/OAuthInfo.kt
@@ -1,0 +1,23 @@
+package com.photi.core.domain.user.model
+
+import jakarta.persistence.Column
+import jakarta.persistence.Embeddable
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+
+@Embeddable
+class OAuthInfo(
+
+    @Enumerated(value = EnumType.STRING)
+    @Column(nullable = true, length = 15)
+    val provider: OAuthProviderType?,
+
+    @Column(nullable = true, length = 255)
+    val sub: String?,
+) {
+
+    companion object {
+
+        fun of(provider: OAuthProviderType, sub: String) = OAuthInfo(provider, sub)
+    }
+}

--- a/photi-core/domain/src/main/kotlin/com/photi/core/domain/user/model/OAuthProviderType.kt
+++ b/photi-core/domain/src/main/kotlin/com/photi/core/domain/user/model/OAuthProviderType.kt
@@ -1,0 +1,7 @@
+package com.photi.core.domain.user.model
+
+enum class OAuthProviderType(private val value: String) {
+    KAKAO("카카오"),
+    GOOGLE("구글"),
+    APPLE("애플"),
+}

--- a/photi-core/domain/src/main/kotlin/com/photi/core/domain/user/model/User.kt
+++ b/photi-core/domain/src/main/kotlin/com/photi/core/domain/user/model/User.kt
@@ -128,5 +128,9 @@ class User(
         deletedDate = null
     }
 
+    fun login(userValidator: UserValidator) {
+        userValidator.validateDeletedUser(this)
+    }
+
     private fun isImageNullOrEmpty() = this.imageUrl.isNullOrEmpty()
 }

--- a/photi-core/domain/src/main/kotlin/com/photi/core/domain/user/model/User.kt
+++ b/photi-core/domain/src/main/kotlin/com/photi/core/domain/user/model/User.kt
@@ -25,6 +25,7 @@ class User(
     username: String? = null,
     oAuthInfo: OAuthInfo? = null,
     role: RoleType = RoleType.UNAUTHENTICATED_USER,
+    imageUrl: String? = null,
 ) : BaseTimeEntity() {
 
     @Id
@@ -58,7 +59,7 @@ class User(
         protected set
 
     @Column(nullable = true, length = 500)
-    var imageUrl: String? = null
+    var imageUrl: String? = imageUrl
         protected set
 
     @Enumerated(value = EnumType.STRING)

--- a/photi-core/domain/src/main/kotlin/com/photi/core/domain/user/model/User.kt
+++ b/photi-core/domain/src/main/kotlin/com/photi/core/domain/user/model/User.kt
@@ -10,11 +10,21 @@ import com.photi.core.domain.user.validator.UserValidator
 import jakarta.persistence.*
 import java.time.LocalDateTime
 
-@Table(name = "users")
+@Table(
+    name = "users",
+    uniqueConstraints = [UniqueConstraint(
+        name = "uq_user_provider_sub",
+        columnNames = ["provider", "sub"]
+    )]
+)
 @Entity
 class User(
     email: String,
-    authenticationCode: String,
+    authenticationCode: String? = null,
+    isAuthenticated: Boolean = false,
+    username: String? = null,
+    oAuthInfo: OAuthInfo? = null,
+    role: RoleType = RoleType.UNAUTHENTICATED_USER,
 ) : BaseTimeEntity() {
 
     @Id
@@ -23,20 +33,24 @@ class User(
     var id: Long? = null
         protected set
 
-    @Column(nullable = false, unique = true, length = 100)
+    @Embedded
+    var oAuthInfo: OAuthInfo? = oAuthInfo
+        protected set
+
+    @Column(nullable = false, length = 100)
     var email: String = email
         protected set
 
-    @Column(nullable = false, length = 6)
-    var authenticationCode: String = authenticationCode
+    @Column(nullable = true, length = 6)
+    var authenticationCode: String? = authenticationCode
         protected set
 
     @Column(nullable = false)
-    var isAuthenticated: Boolean = false
+    var isAuthenticated: Boolean = isAuthenticated
         protected set
 
     @Column(nullable = true, unique = true, length = 20)
-    var username: String? = null
+    var username: String? = username
         protected set
 
     @Column(nullable = true, length = 255)
@@ -49,7 +63,7 @@ class User(
 
     @Enumerated(value = EnumType.STRING)
     @Column(nullable = false, length = 25)
-    var role: RoleType = RoleType.UNAUTHENTICATED_USER
+    var role: RoleType = role
         protected set
 
     @Column(nullable = true)

--- a/photi-core/domain/src/main/kotlin/com/photi/core/domain/user/model/repository/UserRepository.kt
+++ b/photi-core/domain/src/main/kotlin/com/photi/core/domain/user/model/repository/UserRepository.kt
@@ -1,6 +1,7 @@
 package com.photi.core.domain.user.model.repository
 
 import com.photi.core.domain.user.dto.FindInfoDto
+import com.photi.core.domain.user.model.OAuthInfo
 import com.photi.core.domain.user.model.RoleType
 import com.photi.core.domain.user.model.User
 import org.springframework.data.jpa.repository.JpaRepository
@@ -11,6 +12,8 @@ interface UserRepository : JpaRepository<User, Long>, UserCustomRepository {
     fun existsByEmailAndRole(email: String, role: RoleType): Boolean
 
     fun existsByUsername(username: String): Boolean
+
+    fun existsByOAuthInfo(oAuthInfo: OAuthInfo): Boolean
 
     fun findByEmailAndRole(email: String, role: RoleType): User?
 

--- a/photi-core/domain/src/main/kotlin/com/photi/core/domain/user/model/repository/UserRepository.kt
+++ b/photi-core/domain/src/main/kotlin/com/photi/core/domain/user/model/repository/UserRepository.kt
@@ -25,6 +25,8 @@ interface UserRepository : JpaRepository<User, Long>, UserCustomRepository {
 
     fun findByEmailAndUsernameAndIsAuthenticatedTrue(email: String, username: String): User?
 
+    fun findByOAuthInfo(oAuthInfo: OAuthInfo): User?
+
     @Query("select new com.photi.core.domain.user.dto.FindInfoDto(u.imageUrl, u.username, u.email) from User u where u.id = :id")
     fun findInfoById(id: Long): FindInfoDto?
 }

--- a/photi-core/domain/src/main/kotlin/com/photi/core/domain/user/port/OAuthFactoryPort.kt
+++ b/photi-core/domain/src/main/kotlin/com/photi/core/domain/user/port/OAuthFactoryPort.kt
@@ -1,0 +1,8 @@
+package com.photi.core.domain.user.port
+
+import com.photi.core.domain.user.model.OAuthProviderType
+
+interface OAuthFactoryPort {
+
+    fun getOAuthAdapter(provider: OAuthProviderType): OAuthPort
+}

--- a/photi-core/domain/src/main/kotlin/com/photi/core/domain/user/port/OAuthPort.kt
+++ b/photi-core/domain/src/main/kotlin/com/photi/core/domain/user/port/OAuthPort.kt
@@ -1,8 +1,14 @@
 package com.photi.core.domain.user.port
 
+import com.photi.core.domain.common.properties.OAuthProperties
 import com.photi.core.domain.user.dto.OidcPayload
+import com.photi.core.domain.user.model.OAuthInfo
 
 interface OAuthPort {
 
     fun getIdTokenPayload(idToken: String, iss: String, aud: String, nonce: String): OidcPayload
+
+    fun getProperties(): OAuthProperties
+
+    fun createOAuthInfo(sub: String): OAuthInfo
 }

--- a/photi-core/domain/src/main/kotlin/com/photi/core/domain/user/port/OAuthPort.kt
+++ b/photi-core/domain/src/main/kotlin/com/photi/core/domain/user/port/OAuthPort.kt
@@ -1,0 +1,8 @@
+package com.photi.core.domain.user.port
+
+import com.photi.core.domain.user.dto.OidcPayload
+
+interface OAuthPort {
+
+    fun getIdTokenPayload(idToken: String, iss: String, aud: String, nonce: String): OidcPayload
+}

--- a/photi-core/domain/src/main/kotlin/com/photi/core/domain/user/port/OAuthPort.kt
+++ b/photi-core/domain/src/main/kotlin/com/photi/core/domain/user/port/OAuthPort.kt
@@ -6,7 +6,7 @@ import com.photi.core.domain.user.model.OAuthInfo
 
 interface OAuthPort {
 
-    fun getIdTokenPayload(idToken: String, iss: String, aud: String, nonce: String): OidcPayload
+    fun getIdTokenPayload(idToken: String, iss: String, aud: String): OidcPayload
 
     fun getProperties(): OAuthProperties
 

--- a/photi-core/domain/src/main/kotlin/com/photi/core/domain/user/service/OAuthService.kt
+++ b/photi-core/domain/src/main/kotlin/com/photi/core/domain/user/service/OAuthService.kt
@@ -29,7 +29,12 @@ class OAuthService(
         val idTokenPayload = getOidcPayload(idToken, oAuthPort)
         val oAuthInfo = oAuthPort.createOAuthInfo(idTokenPayload.sub)
         if (userQueryService.existsBy(oAuthInfo)) throw UserException.ExistsUserException()
-        val user = userCommandService.createUser(dto, oAuthInfo, idTokenPayload.email)
+        val user = userCommandService.createUser(
+            dto,
+            oAuthInfo,
+            idTokenPayload.email,
+            idTokenPayload.image,
+        )
         return SignUpDto.of(user)
     }
 

--- a/photi-core/domain/src/main/kotlin/com/photi/core/domain/user/service/OAuthService.kt
+++ b/photi-core/domain/src/main/kotlin/com/photi/core/domain/user/service/OAuthService.kt
@@ -53,7 +53,7 @@ class OAuthService(
         return oAuthPort.getIdTokenPayload(
             idToken,
             properties.baseUrl,
-            properties.restApiKey,
+            properties.nativeAppKey,
             "nonce", // todo '인가 코드 요청 api' 요청 시 전달한 nonce 값과 동일한 값
         )
     }

--- a/photi-core/domain/src/main/kotlin/com/photi/core/domain/user/service/OAuthService.kt
+++ b/photi-core/domain/src/main/kotlin/com/photi/core/domain/user/service/OAuthService.kt
@@ -1,11 +1,12 @@
 package com.photi.core.domain.user.service
 
-import com.photi.core.domain.common.properties.KakaoOAuthProperties
 import com.photi.core.domain.user.dto.LoginDto
 import com.photi.core.domain.user.dto.OAuthSignUpDto
+import com.photi.core.domain.user.dto.OidcPayload
 import com.photi.core.domain.user.dto.SignUpDto
 import com.photi.core.domain.user.exception.UserException
-import com.photi.core.domain.user.model.OAuthInfo
+import com.photi.core.domain.user.model.OAuthProviderType
+import com.photi.core.domain.user.port.OAuthFactoryPort
 import com.photi.core.domain.user.port.OAuthPort
 import com.photi.core.domain.user.service.command.UserCommandService
 import com.photi.core.domain.user.service.query.UserQueryService
@@ -16,35 +17,39 @@ import org.springframework.transaction.annotation.Transactional
 @Service
 @Transactional(readOnly = true)
 class OAuthService(
-    private val oAuthPort: OAuthPort,
-    private val kakaoOAuthProperties: KakaoOAuthProperties,
+    private val oAuthFactory: OAuthFactoryPort,
     private val userCommandService: UserCommandService,
     private val userQueryService: UserQueryService,
     private val userValidator: UserValidator,
 ) {
 
     @Transactional
-    fun kakaoSignUp(idToken: String, dto: OAuthSignUpDto): SignUpDto {
-        val idTokenPayload = getOidcPayload(idToken)
-        val oAuthInfo = OAuthInfo.ofKakao(idTokenPayload.sub)
+    fun signUp(provider: OAuthProviderType, idToken: String, dto: OAuthSignUpDto): SignUpDto {
+        val oAuthPort = oAuthFactory.getOAuthAdapter(provider)
+        val idTokenPayload = getOidcPayload(idToken, oAuthPort)
+        val oAuthInfo = oAuthPort.createOAuthInfo(idTokenPayload.sub)
         if (userQueryService.existsBy(oAuthInfo)) throw UserException.ExistsUserException()
         val user = userCommandService.createUser(dto, oAuthInfo, idTokenPayload.email)
         return SignUpDto.of(user)
     }
 
-    fun kakaoLogin(idToken: String): LoginDto {
-        val idTokenPayload = getOidcPayload(idToken)
-        val oAuthInfo = OAuthInfo.ofKakao(idTokenPayload.sub)
+    fun login(provider: OAuthProviderType, idToken: String): LoginDto {
+        val oAuthPort = oAuthFactory.getOAuthAdapter(provider)
+        val idTokenPayload = getOidcPayload(idToken, oAuthPort)
+        val oAuthInfo = oAuthPort.createOAuthInfo(idTokenPayload.sub)
         val user = userQueryService.getLoginUserBy(oAuthInfo)
             ?: throw UserException.NotFoundUserException()
         user.login(userValidator)
         return LoginDto.of(user)
     }
 
-    private fun getOidcPayload(idToken: String) = oAuthPort.getIdTokenPayload(
-        idToken,
-        kakaoOAuthProperties.baseUrl,
-        kakaoOAuthProperties.restApiKey,
-        "nonce", // todo '인가 코드 요청 api' 요청 시 전달한 nonce 값과 동일한 값
-    )
+    private fun getOidcPayload(idToken: String, oAuthPort: OAuthPort): OidcPayload {
+        val properties = oAuthPort.getProperties()
+        return oAuthPort.getIdTokenPayload(
+            idToken,
+            properties.baseUrl,
+            properties.restApiKey,
+            "nonce", // todo '인가 코드 요청 api' 요청 시 전달한 nonce 값과 동일한 값
+        )
+    }
 }

--- a/photi-core/domain/src/main/kotlin/com/photi/core/domain/user/service/OAuthService.kt
+++ b/photi-core/domain/src/main/kotlin/com/photi/core/domain/user/service/OAuthService.kt
@@ -1,14 +1,15 @@
 package com.photi.core.domain.user.service
 
 import com.photi.core.domain.common.properties.KakaoOAuthProperties
+import com.photi.core.domain.user.dto.LoginDto
 import com.photi.core.domain.user.dto.OAuthSignUpDto
 import com.photi.core.domain.user.dto.SignUpDto
 import com.photi.core.domain.user.exception.UserException
 import com.photi.core.domain.user.model.OAuthInfo
-import com.photi.core.domain.user.model.OAuthProviderType
 import com.photi.core.domain.user.port.OAuthPort
 import com.photi.core.domain.user.service.command.UserCommandService
 import com.photi.core.domain.user.service.query.UserQueryService
+import com.photi.core.domain.user.validator.UserValidator
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -19,19 +20,31 @@ class OAuthService(
     private val kakaoOAuthProperties: KakaoOAuthProperties,
     private val userCommandService: UserCommandService,
     private val userQueryService: UserQueryService,
+    private val userValidator: UserValidator,
 ) {
 
     @Transactional
     fun kakaoSignUp(idToken: String, dto: OAuthSignUpDto): SignUpDto {
-        val idTokenPayload = oAuthPort.getIdTokenPayload(
-            idToken,
-            kakaoOAuthProperties.baseUrl,
-            kakaoOAuthProperties.restApiKey,
-            "nonce", // todo '인가 코드 요청 api' 요청 시 전달한 nonce 값과 동일한 값
-        )
-        val oAuthInfo = OAuthInfo.of(OAuthProviderType.KAKAO, idTokenPayload.sub)
+        val idTokenPayload = getOidcPayload(idToken)
+        val oAuthInfo = OAuthInfo.ofKakao(idTokenPayload.sub)
         if (userQueryService.existsBy(oAuthInfo)) throw UserException.ExistsUserException()
         val user = userCommandService.createUser(dto, oAuthInfo, idTokenPayload.email)
         return SignUpDto.of(user)
     }
+
+    fun kakaoLogin(idToken: String): LoginDto {
+        val idTokenPayload = getOidcPayload(idToken)
+        val oAuthInfo = OAuthInfo.ofKakao(idTokenPayload.sub)
+        val user = userQueryService.getLoginUserBy(oAuthInfo)
+            ?: throw UserException.NotFoundUserException()
+        user.login(userValidator)
+        return LoginDto.of(user)
+    }
+
+    private fun getOidcPayload(idToken: String) = oAuthPort.getIdTokenPayload(
+        idToken,
+        kakaoOAuthProperties.baseUrl,
+        kakaoOAuthProperties.restApiKey,
+        "nonce", // todo '인가 코드 요청 api' 요청 시 전달한 nonce 값과 동일한 값
+    )
 }

--- a/photi-core/domain/src/main/kotlin/com/photi/core/domain/user/service/OAuthService.kt
+++ b/photi-core/domain/src/main/kotlin/com/photi/core/domain/user/service/OAuthService.kt
@@ -1,0 +1,37 @@
+package com.photi.core.domain.user.service
+
+import com.photi.core.domain.common.properties.KakaoOAuthProperties
+import com.photi.core.domain.user.dto.OAuthSignUpDto
+import com.photi.core.domain.user.dto.SignUpDto
+import com.photi.core.domain.user.exception.UserException
+import com.photi.core.domain.user.model.OAuthInfo
+import com.photi.core.domain.user.model.OAuthProviderType
+import com.photi.core.domain.user.port.OAuthPort
+import com.photi.core.domain.user.service.command.UserCommandService
+import com.photi.core.domain.user.service.query.UserQueryService
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class OAuthService(
+    private val oAuthPort: OAuthPort,
+    private val kakaoOAuthProperties: KakaoOAuthProperties,
+    private val userCommandService: UserCommandService,
+    private val userQueryService: UserQueryService,
+) {
+
+    @Transactional
+    fun kakaoSignUp(idToken: String, dto: OAuthSignUpDto): SignUpDto {
+        val idTokenPayload = oAuthPort.getIdTokenPayload(
+            idToken,
+            kakaoOAuthProperties.baseUrl,
+            kakaoOAuthProperties.restApiKey,
+            "nonce", // todo '인가 코드 요청 api' 요청 시 전달한 nonce 값과 동일한 값
+        )
+        val oAuthInfo = OAuthInfo.of(OAuthProviderType.KAKAO, idTokenPayload.sub)
+        if (userQueryService.existsBy(oAuthInfo)) throw UserException.ExistsUserException()
+        val user = userCommandService.createUser(dto, oAuthInfo, idTokenPayload.email)
+        return SignUpDto.of(user)
+    }
+}

--- a/photi-core/domain/src/main/kotlin/com/photi/core/domain/user/service/OAuthService.kt
+++ b/photi-core/domain/src/main/kotlin/com/photi/core/domain/user/service/OAuthService.kt
@@ -50,11 +50,6 @@ class OAuthService(
 
     private fun getOidcPayload(idToken: String, oAuthPort: OAuthPort): OidcPayload {
         val properties = oAuthPort.getProperties()
-        return oAuthPort.getIdTokenPayload(
-            idToken,
-            properties.baseUrl,
-            properties.nativeAppKey,
-            "nonce", // todo '인가 코드 요청 api' 요청 시 전달한 nonce 값과 동일한 값
-        )
+        return oAuthPort.getIdTokenPayload(idToken, properties.baseUrl, properties.nativeAppKey)
     }
 }

--- a/photi-core/domain/src/main/kotlin/com/photi/core/domain/user/service/command/UserCommandService.kt
+++ b/photi-core/domain/src/main/kotlin/com/photi/core/domain/user/service/command/UserCommandService.kt
@@ -1,6 +1,8 @@
 package com.photi.core.domain.user.service.command
 
+import com.photi.core.domain.user.dto.OAuthSignUpDto
 import com.photi.core.domain.user.dto.SendEmailAuthenticationCodeDto
+import com.photi.core.domain.user.model.OAuthInfo
 import com.photi.core.domain.user.model.repository.UserRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -14,4 +16,7 @@ class UserCommandService(
     fun createUser(dto: SendEmailAuthenticationCodeDto, authenticationCode: String) {
         userRepository.save(dto.toEntity(authenticationCode))
     }
+
+    fun createUser(dto: OAuthSignUpDto, oAuthInfo: OAuthInfo, email: String) =
+        userRepository.save(dto.toEntity(oAuthInfo, email))
 }

--- a/photi-core/domain/src/main/kotlin/com/photi/core/domain/user/service/command/UserCommandService.kt
+++ b/photi-core/domain/src/main/kotlin/com/photi/core/domain/user/service/command/UserCommandService.kt
@@ -17,6 +17,6 @@ class UserCommandService(
         userRepository.save(dto.toEntity(authenticationCode))
     }
 
-    fun createUser(dto: OAuthSignUpDto, oAuthInfo: OAuthInfo, email: String) =
-        userRepository.save(dto.toEntity(oAuthInfo, email))
+    fun createUser(dto: OAuthSignUpDto, oAuthInfo: OAuthInfo, email: String, image: String) =
+        userRepository.save(dto.toEntity(oAuthInfo, email, image))
 }

--- a/photi-core/domain/src/main/kotlin/com/photi/core/domain/user/service/query/UserQueryService.kt
+++ b/photi-core/domain/src/main/kotlin/com/photi/core/domain/user/service/query/UserQueryService.kt
@@ -1,5 +1,6 @@
 package com.photi.core.domain.user.service.query
 
+import com.photi.core.domain.user.model.OAuthInfo
 import com.photi.core.domain.user.model.RoleType
 import com.photi.core.domain.user.model.repository.UserRepository
 import org.springframework.data.domain.PageRequest
@@ -53,4 +54,6 @@ class UserQueryService(
     fun existsEmail(email: String) = userRepository.existsByEmailAndRole(email, RoleType.USER)
 
     fun existsUsername(username: String) = userRepository.existsByUsername(username)
+
+    fun existsBy(oAuthInfo: OAuthInfo) = userRepository.existsByOAuthInfo(oAuthInfo)
 }

--- a/photi-core/domain/src/main/kotlin/com/photi/core/domain/user/service/query/UserQueryService.kt
+++ b/photi-core/domain/src/main/kotlin/com/photi/core/domain/user/service/query/UserQueryService.kt
@@ -23,6 +23,8 @@ class UserQueryService(
 
     fun getLoginUserBy(username: String) = userRepository.findByUsername(username)
 
+    fun getLoginUserBy(oAuthInfo: OAuthInfo) = userRepository.findByOAuthInfo(oAuthInfo)
+
     fun getAuthenticatedUserBy(email: String) =
         userRepository.findByEmailAndIsAuthenticatedTrue(email)
 

--- a/photi-core/domain/src/main/kotlin/com/photi/core/domain/user/validator/UserValidator.kt
+++ b/photi-core/domain/src/main/kotlin/com/photi/core/domain/user/validator/UserValidator.kt
@@ -48,7 +48,7 @@ class UserValidator(
         validateUsername(username)
     }
 
-    private fun validateDeletedUser(user: User) {
+    fun validateDeletedUser(user: User) {
         if (user.role == RoleType.DELETED_USER) {
             throw UserException.ExistsDeletedUserException()
         }

--- a/photi-core/domain/src/main/resources/db/migration/V8__add_provider_sub_in_user.sql
+++ b/photi-core/domain/src/main/resources/db/migration/V8__add_provider_sub_in_user.sql
@@ -1,0 +1,11 @@
+ALTER TABLE users
+    ADD COLUMN provider VARCHAR(15)  NULL,
+    ADD COLUMN sub      VARCHAR(255) NULL,
+    ALTER COLUMN authentication_code DROP NOT NULL;
+
+ALTER TABLE users
+    DROP CONSTRAINT IF EXISTS uq_email;
+
+ALTER TABLE users
+    ADD CONSTRAINT uq_user_provider_sub
+        UNIQUE (provider, sub);

--- a/photi-core/infra/build.gradle.kts
+++ b/photi-core/infra/build.gradle.kts
@@ -6,9 +6,16 @@ val bootJar: BootJar by tasks
 bootJar.enabled = false
 jar.enabled = true
 
+dependencyManagement {
+    imports {
+        mavenBom("org.springframework.cloud:spring-cloud-dependencies:2024.0.0")
+    }
+}
+
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.springframework.boot:spring-boot-starter-data-redis")
+    implementation("org.springframework.cloud:spring-cloud-starter-openfeign")
     implementation("io.awspring.cloud:spring-cloud-starter-aws:2.4.4")
     implementation("com.querydsl:querydsl-jpa:5.1.0:jakarta")
     implementation(project(":photi-core:domain"))

--- a/photi-core/infra/src/main/kotlin/com/photi/core/infra/PhotiConfigGroup.kt
+++ b/photi-core/infra/src/main/kotlin/com/photi/core/infra/PhotiConfigGroup.kt
@@ -1,8 +1,11 @@
 package com.photi.core.infra
 
 import com.photi.core.infra.async.AsyncConfig
+import com.photi.core.infra.feign.FeignConfig
 import com.photi.core.infra.jpa.JpaConfig
+import com.photi.core.infra.properties.ConfigurationPropertiesConfig
 import com.photi.core.infra.querydsl.QuerydslConfig
+import com.photi.core.infra.redis.RedisCacheConfig
 import com.photi.core.infra.redis.RedisConfig
 import com.photi.core.infra.s3.S3Config
 
@@ -14,4 +17,7 @@ enum class PhotiConfigGroup(
     REDIS(RedisConfig::class.java),
     S3(S3Config::class.java),
     ASYNC(AsyncConfig::class.java),
+    REDIS_CACHE(RedisCacheConfig::class.java),
+    FEIGN(FeignConfig::class.java),
+    CONFIGURATION_PROPERTIES(ConfigurationPropertiesConfig::class.java),
 }

--- a/photi-core/infra/src/main/kotlin/com/photi/core/infra/feign/FeignConfig.kt
+++ b/photi-core/infra/src/main/kotlin/com/photi/core/infra/feign/FeignConfig.kt
@@ -1,0 +1,16 @@
+package com.photi.core.infra.feign
+
+import com.photi.core.infra.PhotiConfig
+import com.photi.core.infra.oauth.client.BaseFeignClientsPackage
+import feign.Logger
+import org.springframework.cloud.openfeign.EnableFeignClients
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+@EnableFeignClients(basePackageClasses = [BaseFeignClientsPackage::class])
+class FeignConfig : PhotiConfig {
+
+    @Bean
+    fun feignLoggerLevel() = Logger.Level.FULL
+}

--- a/photi-core/infra/src/main/kotlin/com/photi/core/infra/oauth/adapter/AppleOAuthAdapter.kt
+++ b/photi-core/infra/src/main/kotlin/com/photi/core/infra/oauth/adapter/AppleOAuthAdapter.kt
@@ -15,14 +15,9 @@ class AppleOAuthAdapter(
     private val jwtOidcPort: JwtOidcPort,
 ) : OAuthPort {
 
-    override fun getIdTokenPayload(
-        idToken: String,
-        iss: String,
-        aud: String,
-        nonce: String,
-    ): OidcPayload {
+    override fun getIdTokenPayload(idToken: String, iss: String, aud: String): OidcPayload {
         val publicKeys = appleOAuthClient.getOidcPublicKeys()
-        val kid = jwtOidcPort.getKidFromUnsignedIdToken(idToken, iss, aud, nonce)
+        val kid = jwtOidcPort.getKidFromUnsignedIdToken(idToken, iss, aud)
         val jwk = publicKeys.keys.first { it.kid == kid }
         return jwtOidcPort.getIdTokenPayload(idToken, jwk.n, jwk.e)
     }

--- a/photi-core/infra/src/main/kotlin/com/photi/core/infra/oauth/adapter/AppleOAuthAdapter.kt
+++ b/photi-core/infra/src/main/kotlin/com/photi/core/infra/oauth/adapter/AppleOAuthAdapter.kt
@@ -1,0 +1,33 @@
+package com.photi.core.infra.oauth.adapter
+
+import com.photi.core.domain.common.properties.AppleOAuthProperties
+import com.photi.core.domain.user.dto.OidcPayload
+import com.photi.core.domain.user.model.OAuthInfo
+import com.photi.core.domain.user.port.OAuthPort
+import com.photi.core.infra.oauth.client.AppleOAuthClient
+import com.photi.core.infra.oauth.port.JwtOidcPort
+import org.springframework.stereotype.Component
+
+@Component
+class AppleOAuthAdapter(
+    private val appleOAuthProperties: AppleOAuthProperties,
+    private val appleOAuthClient: AppleOAuthClient,
+    private val jwtOidcPort: JwtOidcPort,
+) : OAuthPort {
+
+    override fun getIdTokenPayload(
+        idToken: String,
+        iss: String,
+        aud: String,
+        nonce: String,
+    ): OidcPayload {
+        val publicKeys = appleOAuthClient.getOidcPublicKeys()
+        val kid = jwtOidcPort.getKidFromUnsignedIdToken(idToken, iss, aud, nonce)
+        val jwk = publicKeys.keys.first { it.kid == kid }
+        return jwtOidcPort.getIdTokenPayload(idToken, jwk.n, jwk.e)
+    }
+
+    override fun getProperties() = appleOAuthProperties
+
+    override fun createOAuthInfo(sub: String) = OAuthInfo.ofApple(sub)
+}

--- a/photi-core/infra/src/main/kotlin/com/photi/core/infra/oauth/adapter/GoogleOAuthAdapter.kt
+++ b/photi-core/infra/src/main/kotlin/com/photi/core/infra/oauth/adapter/GoogleOAuthAdapter.kt
@@ -1,17 +1,17 @@
 package com.photi.core.infra.oauth.adapter
 
-import com.photi.core.domain.common.properties.KakaoOAuthProperties
+import com.photi.core.domain.common.properties.GoogleOAuthProperties
 import com.photi.core.domain.user.dto.OidcPayload
 import com.photi.core.domain.user.model.OAuthInfo
 import com.photi.core.domain.user.port.OAuthPort
-import com.photi.core.infra.oauth.client.KakaoOAuthClient
+import com.photi.core.infra.oauth.client.GoogleOAuthClient
 import com.photi.core.infra.oauth.port.JwtOidcPort
 import org.springframework.stereotype.Component
 
 @Component
-class KakaoOAuthAdapter(
-    private val kakaoOAuthProperties: KakaoOAuthProperties,
-    private val kakaoOAuthClient: KakaoOAuthClient,
+class GoogleOAuthAdapter(
+    private val googleOAuthProperties: GoogleOAuthProperties,
+    private val googleOAuthClient: GoogleOAuthClient,
     private val jwtOidcPort: JwtOidcPort,
 ) : OAuthPort {
 
@@ -21,13 +21,13 @@ class KakaoOAuthAdapter(
         aud: String,
         nonce: String,
     ): OidcPayload {
-        val publicKeys = kakaoOAuthClient.getOidcPublicKeys()
+        val publicKeys = googleOAuthClient.getOidcPublicKeys()
         val kid = jwtOidcPort.getKidFromUnsignedIdToken(idToken, iss, aud, nonce)
         val jwk = publicKeys.keys.first { it.kid == kid }
         return jwtOidcPort.getIdTokenPayload(idToken, jwk.n, jwk.e)
     }
 
-    override fun getProperties() = kakaoOAuthProperties
+    override fun getProperties() = googleOAuthProperties
 
-    override fun createOAuthInfo(sub: String) = OAuthInfo.ofKakao(sub)
+    override fun createOAuthInfo(sub: String) = OAuthInfo.ofGoogle(sub)
 }

--- a/photi-core/infra/src/main/kotlin/com/photi/core/infra/oauth/adapter/GoogleOAuthAdapter.kt
+++ b/photi-core/infra/src/main/kotlin/com/photi/core/infra/oauth/adapter/GoogleOAuthAdapter.kt
@@ -15,14 +15,9 @@ class GoogleOAuthAdapter(
     private val jwtOidcPort: JwtOidcPort,
 ) : OAuthPort {
 
-    override fun getIdTokenPayload(
-        idToken: String,
-        iss: String,
-        aud: String,
-        nonce: String,
-    ): OidcPayload {
+    override fun getIdTokenPayload(idToken: String, iss: String, aud: String): OidcPayload {
         val publicKeys = googleOAuthClient.getOidcPublicKeys()
-        val kid = jwtOidcPort.getKidFromUnsignedIdToken(idToken, iss, aud, nonce)
+        val kid = jwtOidcPort.getKidFromUnsignedIdToken(idToken, iss, aud)
         val jwk = publicKeys.keys.first { it.kid == kid }
         return jwtOidcPort.getIdTokenPayload(idToken, jwk.n, jwk.e)
     }

--- a/photi-core/infra/src/main/kotlin/com/photi/core/infra/oauth/adapter/KakaoOAuthAdapter.kt
+++ b/photi-core/infra/src/main/kotlin/com/photi/core/infra/oauth/adapter/KakaoOAuthAdapter.kt
@@ -15,14 +15,9 @@ class KakaoOAuthAdapter(
     private val jwtOidcPort: JwtOidcPort,
 ) : OAuthPort {
 
-    override fun getIdTokenPayload(
-        idToken: String,
-        iss: String,
-        aud: String,
-        nonce: String,
-    ): OidcPayload {
+    override fun getIdTokenPayload(idToken: String, iss: String, aud: String): OidcPayload {
         val publicKeys = kakaoOAuthClient.getOidcPublicKeys()
-        val kid = jwtOidcPort.getKidFromUnsignedIdToken(idToken, iss, aud, nonce)
+        val kid = jwtOidcPort.getKidFromUnsignedIdToken(idToken, iss, aud)
         val jwk = publicKeys.keys.first { it.kid == kid }
         return jwtOidcPort.getIdTokenPayload(idToken, jwk.n, jwk.e)
     }

--- a/photi-core/infra/src/main/kotlin/com/photi/core/infra/oauth/adapter/KakaoOAuthAdapter.kt
+++ b/photi-core/infra/src/main/kotlin/com/photi/core/infra/oauth/adapter/KakaoOAuthAdapter.kt
@@ -1,0 +1,26 @@
+package com.photi.core.infra.oauth.adapter
+
+import com.photi.core.domain.user.dto.OidcPayload
+import com.photi.core.domain.user.port.OAuthPort
+import com.photi.core.infra.oauth.client.KakaoOAuthClient
+import com.photi.core.infra.oauth.port.JwtOidcPort
+import org.springframework.stereotype.Component
+
+@Component
+class KakaoOAuthAdapter(
+    private val kakaoOAuthClient: KakaoOAuthClient,
+    private val jwtOidcPort: JwtOidcPort,
+) : OAuthPort {
+
+    override fun getIdTokenPayload(
+        idToken: String,
+        iss: String,
+        aud: String,
+        nonce: String,
+    ): OidcPayload {
+        val publicKeys = kakaoOAuthClient.getOidcPublicKeys()
+        val kid = jwtOidcPort.getKidFromUnsignedIdToken(idToken, iss, aud, nonce)
+        val jwk = publicKeys.keys.first { it.kid == kid }
+        return jwtOidcPort.getIdTokenPayload(idToken, jwk.n, jwk.e)
+    }
+}

--- a/photi-core/infra/src/main/kotlin/com/photi/core/infra/oauth/adapter/OAuthFactoryAdapter.kt
+++ b/photi-core/infra/src/main/kotlin/com/photi/core/infra/oauth/adapter/OAuthFactoryAdapter.kt
@@ -1,0 +1,18 @@
+package com.photi.core.infra.oauth.adapter
+
+import com.photi.core.domain.user.model.OAuthProviderType
+import com.photi.core.domain.user.port.OAuthFactoryPort
+import org.springframework.stereotype.Component
+
+@Component
+class OAuthFactoryAdapter(
+    private val kakaoOAuthAdapter: KakaoOAuthAdapter,
+    private val googleOAuthAdapter: GoogleOAuthAdapter,
+) : OAuthFactoryPort {
+
+    override fun getOAuthAdapter(provider: OAuthProviderType) = when (provider) {
+        OAuthProviderType.KAKAO -> kakaoOAuthAdapter
+        OAuthProviderType.GOOGLE -> googleOAuthAdapter
+        OAuthProviderType.APPLE -> TODO()
+    }
+}

--- a/photi-core/infra/src/main/kotlin/com/photi/core/infra/oauth/adapter/OAuthFactoryAdapter.kt
+++ b/photi-core/infra/src/main/kotlin/com/photi/core/infra/oauth/adapter/OAuthFactoryAdapter.kt
@@ -8,11 +8,12 @@ import org.springframework.stereotype.Component
 class OAuthFactoryAdapter(
     private val kakaoOAuthAdapter: KakaoOAuthAdapter,
     private val googleOAuthAdapter: GoogleOAuthAdapter,
+    private val appleOAuthAdapter: AppleOAuthAdapter,
 ) : OAuthFactoryPort {
 
     override fun getOAuthAdapter(provider: OAuthProviderType) = when (provider) {
         OAuthProviderType.KAKAO -> kakaoOAuthAdapter
         OAuthProviderType.GOOGLE -> googleOAuthAdapter
-        OAuthProviderType.APPLE -> TODO()
+        OAuthProviderType.APPLE -> appleOAuthAdapter
     }
 }

--- a/photi-core/infra/src/main/kotlin/com/photi/core/infra/oauth/client/AppleOAuthClient.kt
+++ b/photi-core/infra/src/main/kotlin/com/photi/core/infra/oauth/client/AppleOAuthClient.kt
@@ -1,0 +1,14 @@
+package com.photi.core.infra.oauth.client
+
+import com.photi.core.infra.oauth.dto.OidcPublicKeysResponse
+import org.springframework.cache.annotation.Cacheable
+import org.springframework.cloud.openfeign.FeignClient
+import org.springframework.web.bind.annotation.GetMapping
+
+@FeignClient(name = "AppleOAuthClient", url = "https://appleid.apple.com")
+interface AppleOAuthClient : OAuthClient {
+
+    @Cacheable(cacheNames = ["AppleOidc"], cacheManager = "oidcCacheManager")
+    @GetMapping("/auth/keys")
+    override fun getOidcPublicKeys(): OidcPublicKeysResponse
+}

--- a/photi-core/infra/src/main/kotlin/com/photi/core/infra/oauth/client/BaseFeignClientsPackage.kt
+++ b/photi-core/infra/src/main/kotlin/com/photi/core/infra/oauth/client/BaseFeignClientsPackage.kt
@@ -1,0 +1,3 @@
+package com.photi.core.infra.oauth.client
+
+interface BaseFeignClientsPackage

--- a/photi-core/infra/src/main/kotlin/com/photi/core/infra/oauth/client/GoogleOAuthClient.kt
+++ b/photi-core/infra/src/main/kotlin/com/photi/core/infra/oauth/client/GoogleOAuthClient.kt
@@ -5,10 +5,10 @@ import org.springframework.cache.annotation.Cacheable
 import org.springframework.cloud.openfeign.FeignClient
 import org.springframework.web.bind.annotation.GetMapping
 
-@FeignClient(name = "KakaoOAuthClient", url = "https://kauth.kakao.com")
-interface KakaoOAuthClient : OAuthClient {
+@FeignClient(name = "GoogleOAuthClient", url = "https://www.googleapis.com")
+interface GoogleOAuthClient : OAuthClient {
 
-    @Cacheable(cacheNames = ["KakaoOidc"], cacheManager = "oidcCacheManager")
-    @GetMapping("/.well-known/jwks.json")
+    @Cacheable(cacheNames = ["GoogleOidc"], cacheManager = "oidcCacheManager")
+    @GetMapping("/oauth2/v3/certs")
     override fun getOidcPublicKeys(): OidcPublicKeysResponse
 }

--- a/photi-core/infra/src/main/kotlin/com/photi/core/infra/oauth/client/KakaoOAuthClient.kt
+++ b/photi-core/infra/src/main/kotlin/com/photi/core/infra/oauth/client/KakaoOAuthClient.kt
@@ -1,0 +1,14 @@
+package com.photi.core.infra.oauth.client
+
+import com.photi.core.infra.oauth.dto.OidcPublicKeysResponse
+import org.springframework.cache.annotation.Cacheable
+import org.springframework.cloud.openfeign.FeignClient
+import org.springframework.web.bind.annotation.GetMapping
+
+@FeignClient(name = "KakaoOAuthClient", url = "https://kauth.kakao.com")
+interface KakaoOAuthClient {
+
+    @Cacheable(cacheNames = ["KakaoOidc"], cacheManager = "oidcCacheManager")
+    @GetMapping("/.well-known/jwks.json")
+    fun getOidcPublicKeys(): OidcPublicKeysResponse
+}

--- a/photi-core/infra/src/main/kotlin/com/photi/core/infra/oauth/client/OAuthClient.kt
+++ b/photi-core/infra/src/main/kotlin/com/photi/core/infra/oauth/client/OAuthClient.kt
@@ -1,0 +1,8 @@
+package com.photi.core.infra.oauth.client
+
+import com.photi.core.infra.oauth.dto.OidcPublicKeysResponse
+
+interface OAuthClient {
+
+    fun getOidcPublicKeys(): OidcPublicKeysResponse
+}

--- a/photi-core/infra/src/main/kotlin/com/photi/core/infra/oauth/dto/OidcPublicKeysResponse.kt
+++ b/photi-core/infra/src/main/kotlin/com/photi/core/infra/oauth/dto/OidcPublicKeysResponse.kt
@@ -1,14 +1,14 @@
 package com.photi.core.infra.oauth.dto
 
 data class OidcPublicKeysResponse(
-    val keys: List<Jwk>,
+    val keys: List<Jwk> = listOf(),
 )
 
 data class Jwk(
-    val kid: String,
-    val kty: String,
-    val alg: String,
-    val use: String,
-    val n: String,
-    val e: String,
+    val kid: String = "",
+    val kty: String = "",
+    val alg: String = "",
+    val use: String = "",
+    val n: String = "",
+    val e: String = "",
 )

--- a/photi-core/infra/src/main/kotlin/com/photi/core/infra/oauth/dto/OidcPublicKeysResponse.kt
+++ b/photi-core/infra/src/main/kotlin/com/photi/core/infra/oauth/dto/OidcPublicKeysResponse.kt
@@ -1,0 +1,14 @@
+package com.photi.core.infra.oauth.dto
+
+data class OidcPublicKeysResponse(
+    val keys: List<Jwk>,
+)
+
+data class Jwk(
+    val kid: String,
+    val kty: String,
+    val alg: String,
+    val use: String,
+    val n: String,
+    val e: String,
+)

--- a/photi-core/infra/src/main/kotlin/com/photi/core/infra/oauth/port/JwtOidcPort.kt
+++ b/photi-core/infra/src/main/kotlin/com/photi/core/infra/oauth/port/JwtOidcPort.kt
@@ -1,0 +1,15 @@
+package com.photi.core.infra.oauth.port
+
+import com.photi.core.domain.user.dto.OidcPayload
+
+interface JwtOidcPort {
+
+    fun getKidFromUnsignedIdToken(
+        idToken: String,
+        iss: String,
+        aud: String,
+        nonce: String,
+    ): String
+
+    fun getIdTokenPayload(idToken: String, modulus: String, exponent: String): OidcPayload
+}

--- a/photi-core/infra/src/main/kotlin/com/photi/core/infra/oauth/port/JwtOidcPort.kt
+++ b/photi-core/infra/src/main/kotlin/com/photi/core/infra/oauth/port/JwtOidcPort.kt
@@ -4,12 +4,7 @@ import com.photi.core.domain.user.dto.OidcPayload
 
 interface JwtOidcPort {
 
-    fun getKidFromUnsignedIdToken(
-        idToken: String,
-        iss: String,
-        aud: String,
-        nonce: String,
-    ): String
+    fun getKidFromUnsignedIdToken(idToken: String, iss: String, aud: String): String
 
     fun getIdTokenPayload(idToken: String, modulus: String, exponent: String): OidcPayload
 }

--- a/photi-core/infra/src/main/kotlin/com/photi/core/infra/properties/ConfigurationPropertiesConfig.kt
+++ b/photi-core/infra/src/main/kotlin/com/photi/core/infra/properties/ConfigurationPropertiesConfig.kt
@@ -1,5 +1,6 @@
 package com.photi.core.infra.properties
 
+import com.photi.core.domain.common.properties.AppleOAuthProperties
 import com.photi.core.domain.common.properties.GoogleOAuthProperties
 import com.photi.core.domain.common.properties.KakaoOAuthProperties
 import com.photi.core.infra.PhotiConfig
@@ -7,5 +8,11 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Configuration
 
 @Configuration
-@EnableConfigurationProperties(value = [KakaoOAuthProperties::class, GoogleOAuthProperties::class])
+@EnableConfigurationProperties(
+    value = [
+        KakaoOAuthProperties::class,
+        GoogleOAuthProperties::class,
+        AppleOAuthProperties::class,
+    ]
+)
 class ConfigurationPropertiesConfig : PhotiConfig

--- a/photi-core/infra/src/main/kotlin/com/photi/core/infra/properties/ConfigurationPropertiesConfig.kt
+++ b/photi-core/infra/src/main/kotlin/com/photi/core/infra/properties/ConfigurationPropertiesConfig.kt
@@ -1,0 +1,10 @@
+package com.photi.core.infra.properties
+
+import com.photi.core.domain.common.properties.KakaoOAuthProperties
+import com.photi.core.infra.PhotiConfig
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+@EnableConfigurationProperties(value = [KakaoOAuthProperties::class])
+class ConfigurationPropertiesConfig : PhotiConfig

--- a/photi-core/infra/src/main/kotlin/com/photi/core/infra/properties/ConfigurationPropertiesConfig.kt
+++ b/photi-core/infra/src/main/kotlin/com/photi/core/infra/properties/ConfigurationPropertiesConfig.kt
@@ -1,10 +1,11 @@
 package com.photi.core.infra.properties
 
+import com.photi.core.domain.common.properties.GoogleOAuthProperties
 import com.photi.core.domain.common.properties.KakaoOAuthProperties
 import com.photi.core.infra.PhotiConfig
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Configuration
 
 @Configuration
-@EnableConfigurationProperties(value = [KakaoOAuthProperties::class])
+@EnableConfigurationProperties(value = [KakaoOAuthProperties::class, GoogleOAuthProperties::class])
 class ConfigurationPropertiesConfig : PhotiConfig

--- a/photi-core/infra/src/main/kotlin/com/photi/core/infra/redis/RedisCacheConfig.kt
+++ b/photi-core/infra/src/main/kotlin/com/photi/core/infra/redis/RedisCacheConfig.kt
@@ -1,0 +1,38 @@
+package com.photi.core.infra.redis
+
+import com.photi.core.infra.PhotiConfig
+import org.springframework.cache.CacheManager
+import org.springframework.cache.annotation.EnableCaching
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.redis.cache.RedisCacheConfiguration
+import org.springframework.data.redis.cache.RedisCacheManager
+import org.springframework.data.redis.connection.RedisConnectionFactory
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer
+import org.springframework.data.redis.serializer.RedisSerializationContext
+import org.springframework.data.redis.serializer.StringRedisSerializer
+import java.time.Duration
+
+@Configuration
+@EnableCaching
+class RedisCacheConfig : PhotiConfig {
+
+    @Bean
+    fun oidcCacheManager(connectionFactory: RedisConnectionFactory): CacheManager {
+        val cacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
+            .serializeKeysWith(
+                RedisSerializationContext.SerializationPair.fromSerializer(
+                    StringRedisSerializer()
+                )
+            )
+            .serializeValuesWith(
+                RedisSerializationContext.SerializationPair.fromSerializer(
+                    GenericJackson2JsonRedisSerializer()
+                )
+            )
+            .entryTtl(Duration.ofDays(7L))
+        return RedisCacheManager.builder(connectionFactory)
+            .cacheDefaults(cacheConfiguration)
+            .build()
+    }
+}

--- a/photi-core/infra/src/main/resources/application-infra.yml
+++ b/photi-core/infra/src/main/resources/application-infra.yml
@@ -22,6 +22,9 @@ oauth:
   kakao:
     base-url: ${KAKAO_BASE_URL}
     rest-api-key: ${KAKAO_REST_API_KEY}
+  google:
+    base-url: ${GOOGLE_BASE_URL}
+    rest-api-key: ${GOOGLE_REST_API_KEY}
 ---
 spring:
   config:
@@ -47,6 +50,9 @@ oauth:
   kakao:
     base-url: ${KAKAO_BASE_URL}
     rest-api-key: ${KAKAO_REST_API_KEY}
+  google:
+    base-url: ${GOOGLE_BASE_URL}
+    rest-api-key: ${GOOGLE_REST_API_KEY}
 ---
 spring:
   config:

--- a/photi-core/infra/src/main/resources/application-infra.yml
+++ b/photi-core/infra/src/main/resources/application-infra.yml
@@ -17,6 +17,11 @@ cloud:
       bucket: ${AWS_BUCKET}
     stack:
       auto: false
+
+oauth:
+  kakao:
+    base-url: ${KAKAO_BASE_URL}
+    rest-api-key: ${KAKAO_REST_API_KEY}
 ---
 spring:
   config:
@@ -37,6 +42,11 @@ cloud:
       bucket: ${AWS_BUCKET}
     stack:
       auto: false
+
+oauth:
+  kakao:
+    base-url: ${KAKAO_BASE_URL}
+    rest-api-key: ${KAKAO_REST_API_KEY}
 ---
 spring:
   config:

--- a/photi-core/infra/src/main/resources/application-infra.yml
+++ b/photi-core/infra/src/main/resources/application-infra.yml
@@ -25,6 +25,9 @@ oauth:
   google:
     base-url: ${GOOGLE_BASE_URL}
     rest-api-key: ${GOOGLE_REST_API_KEY}
+  apple:
+    base-url: ${APPLE_BASE_URL}
+    rest-api-key: ${APPLE_REST_API_KEY}
 ---
 spring:
   config:
@@ -53,6 +56,9 @@ oauth:
   google:
     base-url: ${GOOGLE_BASE_URL}
     rest-api-key: ${GOOGLE_REST_API_KEY}
+  apple:
+    base-url: ${APPLE_BASE_URL}
+    rest-api-key: ${APPLE_REST_API_KEY}
 ---
 spring:
   config:

--- a/photi-core/infra/src/main/resources/application-infra.yml
+++ b/photi-core/infra/src/main/resources/application-infra.yml
@@ -21,13 +21,13 @@ cloud:
 oauth:
   kakao:
     base-url: ${KAKAO_BASE_URL}
-    rest-api-key: ${KAKAO_REST_API_KEY}
+    native-app-key: ${KAKAO_NATIVE_APP_KEY}
   google:
     base-url: ${GOOGLE_BASE_URL}
-    rest-api-key: ${GOOGLE_REST_API_KEY}
+    native-app-key: ${GOOGLE_NATIVE_APP_KEY}
   apple:
     base-url: ${APPLE_BASE_URL}
-    rest-api-key: ${APPLE_REST_API_KEY}
+    native-app-key: ${APPLE_NATIVE_APP_KEY}
 ---
 spring:
   config:
@@ -52,13 +52,13 @@ cloud:
 oauth:
   kakao:
     base-url: ${KAKAO_BASE_URL}
-    rest-api-key: ${KAKAO_REST_API_KEY}
+    native-app-key: ${KAKAO_NATIVE_APP_KEY}
   google:
     base-url: ${GOOGLE_BASE_URL}
-    rest-api-key: ${GOOGLE_REST_API_KEY}
+    native-app-key: ${GOOGLE_NATIVE_APP_KEY}
   apple:
     base-url: ${APPLE_BASE_URL}
-    rest-api-key: ${APPLE_REST_API_KEY}
+    native-app-key: ${APPLE_NATIVE_APP_KEY}
 ---
 spring:
   config:


### PR DESCRIPTION
## 📋 이슈 번호
- close #277
- close #278
- close #279
  </br>

## 🛠 구현 사항
- oidc 기반 회원가입/로그인 구현
- user 테이블 - provider, sub 컬럼 추가
  </br>

## 📚 기타
- 애플, 구글은 ios, aos 앱 키가 통합되어있지 않아서 수정 필요할 듯
  </br>